### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## v2.0.x
+## v2.1.0
 
 ### Added
 
+- Field with path `pledges.items[].type` [#9]
+- Field with path `pledges.items[].in_pledge` [#9]
 - Repository issues templates
 - Repository PR template
 
@@ -61,3 +63,5 @@
 - Report example `./fields/default/examples/WBAFG41000L194195.json`
 - Report example `./fields/default/examples/Z94CB41AAGR323020.json`
 - Report example `./fields/default/examples/A1111111111111111.json`
+
+[#9]:https://github.com/avtocod/specs/issues/9

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -707,6 +707,20 @@
         ]
     },
     {
+        "path": "pledges.items[].type",
+        "description": "Обременения на ТС: Тип события (возникновение, исключение, прочее)",
+        "types": [
+            "string"
+        ]
+    },
+    {
+        "path": "pledges.items[].in_pledge",
+        "description": "Обременения на ТС: Состояние залога",
+        "types": [
+            "boolean"
+        ]
+    },
+    {
         "path": "pledges.items[].pledgors[].name",
         "description": "Обременения на ТС: Залогодатель (имя)",
         "types": [


### PR DESCRIPTION
Вопрос                | Ответ
--------------------- | ---
Это исправление?      | Да
Это новый функционал? | Нет

Филды `pledges.items[].type` и `pledges.items[].in_pledge` реализованы, но не были отражены в списке всех филдов.

### Added

- Field with path `pledges.items[].type` [#9]
- Field with path `pledges.items[].in_pledge` [#9]
- Repository issues templates
- Repository PR template

Исправление [#9]

[#9]:https://github.com/avtocod/specs/issues/9