### PR TITLE
Add fillable_by field for field's spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Added
+
+- `fillable_by` field for fields specification [#34]
+- Source `tech.base`
+- Source `references.base`
+- Source `av.taxi`
+- Source `pledge.house`
+
+[#34]:https://github.com/avtocod/specs/issues/34
+
+## v2.12.0
+
+### Added 
+
+- Field with path `repairs.history.items[].assessor.name` [#37]
+
+### Fixed
+
+- Field with path `repairs.history.items[].insurer.name` has a duplicate, one instance has been deleted [#37]
+
+[#37]:https://github.com/avtocod/specs/issues/37
+
 ## v2.11.0
 
 ### Changed
@@ -14,14 +38,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- `fillable_by` field for fields specification [#34]
-- Source `tech.base`
-- Source `references.base`
-- Source `av.taxi`
-- Source `pledge.house`
 - **PHP SDK** Static code analyzer `phpstan` installed as `dev` dependency
 
-[#34]:https://github.com/avtocod/specs/issues/34
 [php-supported-versions]:http://php.net/supported-versions.php
 [travis-ci]:https://travis-ci.org/avtocod/specs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.11.0
+
+### Added
+
+- Add `fillable_by` field for fields specification. This version includes sources that we could find out with responces stubs. May be incompleted.
+- Add `references.base` source.
+- Add `tech.base` source.
+- Add `pledge.house` source.
+- Add `av.taxi` source.
+- Add `taxi.registry` source.
+
 ## v2.10.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Added
 
-- Add `fillable_by` field for fields specification. This version includes sources that we could find out with responces stubs. May be incompleted.
-- Add `references.base` source.
-- Add `tech.base` source.
-- Add `pledge.house` source.
-- Add `av.taxi` source.
-- Add `taxi.registry` source.
+- `fillable_by` field for fields specification [#34]
+- Source `references.base`
+- Source `tech.base`
+- Source `pledge.house`
+- Source `av.taxi`
+
+[#34]:https://github.com/avtocod/specs/issues/34
 
 ## v2.10.0
 

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -2307,7 +2307,7 @@
         ]
     },
     {
-        "path": "repairs.history.items[].insurer.name",
+        "path": "repairs.history.items[].assessor.name",
         "description": "Название компании оценщика",
         "types": [
             "string"

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -64,14 +64,16 @@
         "description": "Идентификатор ТС: Номер шасси",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "tech_data.manufacturer.name",
         "description": "Характеристики ТС: Производитель",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "tech_data.brand.id",
@@ -114,7 +116,8 @@
         "description": "Характеристики ТС: Марка (по-русски)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "tech_data.brand.logotype.uri",
@@ -231,7 +234,8 @@
         "description": "Характеристики ТС: Номер шасси",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "tech_data.engine.fuel.type",
@@ -424,7 +428,8 @@
         "description": "Дополнительная информация: Гео-данные владельца (техники)",
         "types": [
             "object"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.sts.date.receive",
@@ -488,7 +493,8 @@
         "description": "Дополнительная информация: Заметки по ТС (техники)",
         "types": [
             "array"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "additional_info.identifiers.vin.checksum_validated",
@@ -505,7 +511,8 @@
         "description": "Дополнительная информация: Были ли изменения в конструкции ТС",
         "types": [
             "boolean"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "diagnostic_cards.items[].date.from",
@@ -723,7 +730,8 @@
         "description": "Регистрационные действия: Гео-данные действия",
         "types": [
             "object"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "insurance.osago.items[].number",
@@ -800,14 +808,16 @@
         "description": "Калькулятор налога: Сумма налога за 12 месяцев (для Москвы)",
         "types": [
             "integer"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "calculate.tax.regions.yearly.amount",
         "description": "Калькулятор налога: Сумма налога за 12 месяцев (для регионов)",
         "types": [
             "integer"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "calculate.osago.coefficients.regional.value",
@@ -1019,21 +1029,24 @@
         "description": "История ДТП: Гео-данные действия",
         "types": [
             "object"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "accidents.history.items[].damage.points",
         "description": "История ДТП: Места повреждений",
         "types": [
             "array"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "accidents.history.items[].damage.raw",
         "description": "История ДТП: Описание повреждений в не нормализованном виде",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "accidents.insurance.items[].date.event",
@@ -1070,7 +1083,8 @@
         "description": "История повреждений из страховых компаний: Размер повреждения или описание",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "accidents.has_accidents",
@@ -1098,7 +1112,8 @@
         "description": "Проверка на угон: Данные о месте угона",
         "types": [
             "object"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "stealings.is_wanted",
@@ -1126,14 +1141,16 @@
         "description": "Утилизация: Имя организации",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "utilizations.items[].country.name",
         "description": "Утилизация: Имя страны",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "utilizations.was_utilized",
@@ -1171,7 +1188,8 @@
         "description": "Ограничения на рег. действия: Дата окончания действия ограничения",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "restrictions.registration_actions.items[].vehicle.year",
@@ -1302,42 +1320,48 @@
         "description": "Обременения на ТС: Залогодатель (имя)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "pledges.items[].pledgors[].type",
         "description": "Обременения на ТС: Залогодатель (тип)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "pledges.items[].pledgors[].dob",
         "description": "Обременения на ТС: Залогодатель (dob)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "pledges.items[].pledgees[].name",
         "description": "Обременения на ТС: Залогодержатель (имя)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "pledges.items[].pledgees[].type",
         "description": "Обременения на ТС: Залогодержатель (тип)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "pledges.items[].pledgees[].dob",
         "description": "Обременения на ТС: Залогодержатель (dob)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "pledges.items[].data",
@@ -1345,7 +1369,8 @@
         "types": [
             "string",
             "array"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].date.event",
@@ -1364,7 +1389,8 @@
         "description": "История по таможне: Имя документа",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].document.number",
@@ -1403,7 +1429,8 @@
         "description": "История по таможне: Пошлина",
         "types": [
             "integer"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].price.amount",
@@ -1473,7 +1500,8 @@
         "description": "История по таможне: Владелец",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].country.from.name",
@@ -1561,8 +1589,7 @@
         "fillable_by": [
             "av.taxi",
             "base.taxi",
-            "base.tech",
-            "taxi.registry"
+            "base.tech"
         ]
     },
     {
@@ -1573,8 +1600,7 @@
         ],
         "fillable_by": [
             "av.taxi",
-            "base.tech",
-            "taxi.registry"
+            "base.tech"
         ]
     },
     {
@@ -1584,8 +1610,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1595,7 +1620,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1605,7 +1630,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1617,8 +1642,7 @@
         "fillable_by": [
             "av.taxi",
             "base.taxi",
-            "base.tech",
-            "taxi.registry"
+            "base.tech"
         ]
     },
     {
@@ -1626,7 +1650,8 @@
         "description": "Такси: Адрес компании или ИП (перевозчика)",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "taxi.history.items[].ogrn",
@@ -1635,8 +1660,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1647,7 +1671,7 @@
         ],
         "fillable_by": [
             "base.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1655,7 +1679,8 @@
         "description": "Такси: Желтый ли номерной знак?",
         "types": [
             "boolean"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "taxi.history.items[].vehicle.brand.name",
@@ -1664,8 +1689,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1675,7 +1699,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1685,8 +1709,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1696,7 +1719,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1704,7 +1727,8 @@
         "description": "Такси: Цвет автомобиля",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "taxi.history.items[].vehicle.reg_num",
@@ -1713,8 +1737,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1724,8 +1747,7 @@
             "integer"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1735,7 +1757,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1745,7 +1767,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1755,7 +1777,7 @@
             "string"
         ],
         "fillable_by": [
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1763,14 +1785,16 @@
         "description": "Такси: Причина отзыва лицензии",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "taxi.history.items[].cancel.note",
         "description": "Такси: Заметка об отзыве лицензии",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "taxi.history.items[].permit.number",
@@ -1779,8 +1803,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -1790,8 +1813,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "taxi.registry"
+            "av.taxi"
         ]
     },
     {
@@ -2080,7 +2102,8 @@
         "description": "car_price: Дата выпуска автомобиля",
         "types": [
             "string"
-        ]
+        ],
+        "fillable_by": []
     },
     {
         "path": "car_price.items[].amount",

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -1,7 +1,7 @@
 [
     {
         "path": "identifiers.vehicle.vin",
-        "description": "Идентификатор ТС: VIN",
+        "description": "Идентификатор ТС: VIN код",
         "types": [
             "string"
         ],
@@ -17,7 +17,7 @@
     },
     {
         "path": "identifiers.vehicle.reg_num",
-        "description": "Идентификатор ТС: ГРЗ",
+        "description": "Идентификатор ТС: Государственный регистрационный знак (ГРЗ)",
         "types": [
             "string"
         ],
@@ -29,7 +29,7 @@
     },
     {
         "path": "identifiers.vehicle.sts",
-        "description": "Идентификатор ТС: СТС",
+        "description": "Идентификатор ТС: Номер СТС (свидетельства регистрации ТС)",
         "types": [
             "string"
         ],
@@ -40,7 +40,7 @@
     },
     {
         "path": "identifiers.vehicle.pts",
-        "description": "Идентификатор ТС: ПТС",
+        "description": "Идентификатор ТС: Номер ПТС (паспорт ТС)",
         "types": [
             "string"
         ],
@@ -74,7 +74,7 @@
     },
     {
         "path": "tech_data.manufacturer.name",
-        "description": "Характеристики ТС: Производитель",
+        "description": "Характеристики ТС: Наименование производителя",
         "types": [
             "string"
         ],
@@ -125,7 +125,7 @@
     },
     {
         "path": "tech_data.brand.logotype.uri",
-        "description": "Характеристики ТС: URI логотипа марки ТС",
+        "description": "Характеристики ТС: URI изображения логотипа марки",
         "types": [
             "string"
         ],
@@ -135,7 +135,7 @@
     },
     {
         "path": "tech_data.model.id",
-        "description": "Характеристики ТС: Уникальный идентификатор модель",
+        "description": "Характеристики ТС: Уникальный идентификатор модели",
         "types": [
             "string"
         ],
@@ -166,7 +166,7 @@
     },
     {
         "path": "tech_data.type.name",
-        "description": "Характеристики ТС: Тип (Вид) ТС",
+        "description": "Характеристики ТС: Тип кузова ТС [Седан, Универсал, ...]",
         "types": [
             "string"
         ],
@@ -191,7 +191,7 @@
     },
     {
         "path": "tech_data.body.color.name",
-        "description": "Характеристики ТС: Цвет",
+        "description": "Характеристики ТС: Цвет кузова",
         "types": [
             "string"
         ],
@@ -203,7 +203,7 @@
     },
     {
         "path": "tech_data.body.color.type",
-        "description": "Характеристики ТС: Тип цвета",
+        "description": "Характеристики ТС: Тип цвета кузова",
         "types": [
             "string"
         ],
@@ -240,7 +240,7 @@
     },
     {
         "path": "tech_data.engine.fuel.type",
-        "description": "Характеристики ТС: Тип топлива",
+        "description": "Характеристики ТС: Тип топлива [Бензиновый, Дизельный, Прочее]",
         "types": [
             "string"
         ],
@@ -337,7 +337,7 @@
     },
     {
         "path": "tech_data.transmission.type",
-        "description": "Характеристики ТС: Трансмиссия",
+        "description": "Характеристики ТС: Тип трансмиссии [AUTOMATIC, MANUAL, ROBOT, VARIABLE, UNKNOWN]",
         "types": [
             "string"
         ],
@@ -345,7 +345,7 @@
     },
     {
         "path": "tech_data.drive.type",
-        "description": "Характеристики ТС: Тип привода",
+        "description": "Характеристики ТС: Тип привода [Заднеприводной, Переднеприводной, Полноприводной, Иные]",
         "types": [
             "string"
         ],
@@ -356,7 +356,7 @@
     },
     {
         "path": "tech_data.wheel.position",
-        "description": "Характеристики ТС: Расположение руля",
+        "description": "Характеристики ТС: Расположение руля [LEFT, RIGHT, UNKNOWN]",
         "types": [
             "string"
         ],
@@ -368,7 +368,7 @@
     },
     {
         "path": "additional_info.vehicle.category.code",
-        "description": "Дополнительная информация: Код категории ТС",
+        "description": "Дополнительная информация: Код категории ТС [A, B, B1, ...]",
         "types": [
             "string"
         ],
@@ -394,7 +394,7 @@
     },
     {
         "path": "additional_info.vehicle.owner.type",
-        "description": "Дополнительная информация: Тип владельца (техники)",
+        "description": "Дополнительная информация: Тип владельца (техники) [PERSON, LEGAL, PERSONLEGAL, UNKNOWN, NONE]",
         "types": [
             "string"
         ],
@@ -426,7 +426,7 @@
     },
     {
         "path": "additional_info.vehicle.passport.date.receive",
-        "description": "Дополнительная информация: Дата выдачи паспорта ТС (техники)",
+        "description": "Дополнительная информация: Дата выдачи паспорта ТС",
         "types": [
             "string"
         ],
@@ -478,7 +478,7 @@
     },
     {
         "path": "additional_info.identifiers.vin.checksum_validated",
-        "description": "Дополнительная информация: Проверка контрольного символа VIN",
+        "description": "Дополнительная информация: Пройдена ли проверка контрольного символа VIN?",
         "types": [
             "boolean"
         ],
@@ -488,7 +488,7 @@
     },
     {
         "path": "additional_info.vehicle.modifications.was_modificated",
-        "description": "Дополнительная информация: Были ли изменения в конструкции ТС",
+        "description": "Дополнительная информация: Были ли изменения в конструкции ТС?",
         "types": [
             "boolean"
         ],
@@ -499,7 +499,7 @@
     },
     {
         "path": "diagnostic_cards.items[].date.from",
-        "description": "Диагностические карты: Дата начала",
+        "description": "Диагностические карты: Дата начала действия",
         "types": [
             "string"
         ],
@@ -510,7 +510,7 @@
     },
     {
         "path": "diagnostic_cards.items[].date.to",
-        "description": "Диагностические карты: Дата ПО",
+        "description": "Диагностические карты: Дата окончания действия",
         "types": [
             "string"
         ],
@@ -565,7 +565,7 @@
     },
     {
         "path": "diagnostic_cards.items[].reg_num",
-        "description": "Диагностические карты: ГРЗ знак",
+        "description": "Диагностические карты: Государственный регистрационный знак",
         "types": [
             "string"
         ],
@@ -596,7 +596,7 @@
     },
     {
         "path": "ownership.history.items[].owner.type",
-        "description": "История владения: Тип владельца",
+        "description": "История владения: Тип владельца [PERSON, LEGAL, PERSONLEGAL, UNKNOWN, NONE]",
         "types": [
             "string"
         ],
@@ -630,7 +630,7 @@
     },
     {
         "path": "registration_actions.items[].reg_num",
-        "description": "Регистрационные действия: ГРЗ знак",
+        "description": "Регистрационные действия: Государственный регистрационный знак",
         "types": [
             "string"
         ],
@@ -662,7 +662,7 @@
     },
     {
         "path": "registration_actions.items[].owner.type",
-        "description": "Регистрационные действия: Тип владельца",
+        "description": "Регистрационные действия: Тип владельца [PERSON, LEGAL, PERSONLEGAL, UNKNOWN, NONE]",
         "types": [
             "string"
         ],
@@ -719,7 +719,7 @@
     },
     {
         "path": "insurance.osago.items[].insurer.name",
-        "description": "ОСАГО: Страховщик",
+        "description": "ОСАГО: Наименование страховщика",
         "types": [
             "string"
         ],
@@ -729,7 +729,7 @@
     },
     {
         "path": "insurance.osago.items[].date.start",
-        "description": "ОСАГО: Дата начала",
+        "description": "ОСАГО: Дата начала действия полиса",
         "types": [
             "string"
         ],
@@ -738,7 +738,7 @@
     },
     {
         "path": "insurance.osago.items[].date.end",
-        "description": "ОСАГО: Дата окончания",
+        "description": "ОСАГО: Дата окончания действия полиса",
         "types": [
             "string"
         ],
@@ -834,7 +834,7 @@
     },
     {
         "path": "calculate.osago.price.current.yearly.min",
-        "description": "Калькулятор ОСАГО: Мин сумма ОСАГО для регионов",
+        "description": "Калькулятор ОСАГО: Минимальная стоимость ОСАГО для регионов",
         "types": [
             "integer"
         ],
@@ -844,7 +844,7 @@
     },
     {
         "path": "calculate.osago.price.current.yearly.max",
-        "description": "Калькулятор ОСАГО: Макс сумма ОСАГО для регионов",
+        "description": "Калькулятор ОСАГО: Максимальная стоимость ОСАГО для регионов",
         "types": [
             "integer"
         ],
@@ -934,7 +934,7 @@
     },
     {
         "path": "accidents.history.items[].type",
-        "description": "История ДТП: Тип происшествия",
+        "description": "История ДТП: Тип происшествия [Столкновение, Наезд на стоящее ТС, ...]",
         "types": [
             "string"
         ],
@@ -944,7 +944,7 @@
     },
     {
         "path": "accidents.history.items[].state",
-        "description": "История ДТП: Статус ТС",
+        "description": "История ДТП: Статус ТС [Повреждено, ...]",
         "types": [
             "string"
         ],
@@ -1004,7 +1004,7 @@
     },
     {
         "path": "accidents.history.items[].damage.points",
-        "description": "История ДТП: Места повреждений",
+        "description": "История ДТП: Места повреждений (коды мест повреждений ТС)",
         "types": [
             "array"
         ],
@@ -1014,7 +1014,7 @@
     },
     {
         "path": "accidents.history.items[].damage.raw",
-        "description": "История ДТП: Описание повреждений в не нормализованном виде",
+        "description": "История ДТП: Описание повреждений в не-нормализованном виде",
         "types": [
             "string"
         ],
@@ -1034,7 +1034,7 @@
     },
     {
         "path": "accidents.insurance.items[].insurer.type",
-        "description": "История повреждений из страховых компаний: Тип страхования (ОСАГО, КАСКО)",
+        "description": "История повреждений из страховых компаний: Тип страхования [ОСАГО, КАСКО, ...]",
         "types": [
             "string"
         ],
@@ -1125,7 +1125,7 @@
     },
     {
         "path": "utilizations.items[].country.name",
-        "description": "Утилизация: Имя страны",
+        "description": "Утилизация: Наименование страны",
         "types": [
             "string"
         ],
@@ -1277,7 +1277,7 @@
     },
     {
         "path": "pledges.items[].type",
-        "description": "Обременения на ТС: Тип события (возникновение, исключение, прочее)",
+        "description": "Обременения на ТС: Тип события [Возникновение, Исключение, ...]",
         "types": [
             "string"
         ],
@@ -1310,7 +1310,7 @@
     },
     {
         "path": "pledges.items[].pledgors[].type",
-        "description": "Обременения на ТС: Залогодатель (тип)",
+        "description": "Обременения на ТС: Тип залогодателя [PERSON, LEGAL, PERSONLEGAL, UNKNOWN, NONE]",
         "types": [
             "string"
         ],
@@ -1321,7 +1321,7 @@
     },
     {
         "path": "pledges.items[].pledgors[].dob",
-        "description": "Обременения на ТС: Залогодатель (dob)",
+        "description": "Обременения на ТС: Дата рождения залогодателя",
         "types": [
             "string"
         ],
@@ -1332,7 +1332,7 @@
     },
     {
         "path": "pledges.items[].pledgees[].name",
-        "description": "Обременения на ТС: Залогодержатель (имя)",
+        "description": "Обременения на ТС: Имя залогодержателя",
         "types": [
             "string"
         ],
@@ -1343,7 +1343,7 @@
     },
     {
         "path": "pledges.items[].pledgees[].type",
-        "description": "Обременения на ТС: Залогодержатель (тип)",
+        "description": "Обременения на ТС: Тип залогодержателя [PERSON, LEGAL, PERSONLEGAL, UNKNOWN, NONE]",
         "types": [
             "string"
         ],
@@ -1354,7 +1354,7 @@
     },
     {
         "path": "pledges.items[].pledgees[].dob",
-        "description": "Обременения на ТС: Залогодержатель (dob)",
+        "description": "Обременения на ТС: Дата рождения залогодержателя",
         "types": [
             "string"
         ],
@@ -1365,7 +1365,7 @@
     },
     {
         "path": "pledges.items[].data",
-        "description": "Обременения на ТС: Данные",
+        "description": "Обременения на ТС: Дополнительные данные",
         "types": [
             "string",
             "array"
@@ -1377,7 +1377,7 @@
     },
     {
         "path": "customs.history.items[].date.event",
-        "description": "История по таможне: Дата",
+        "description": "История по таможне: Дата прохождения таможни",
         "types": [
             "string"
         ],
@@ -1428,7 +1428,7 @@
     },
     {
         "path": "customs.history.items[].tax.amount",
-        "description": "История по таможне: Пошлина",
+        "description": "История по таможне: Сумма пошлины",
         "types": [
             "integer"
         ],
@@ -1532,7 +1532,7 @@
     },
     {
         "path": "leasings.items[].tin",
-        "description": "Лизинг: ИНН (Taxpayer identification number)",
+        "description": "Лизинг: Номер ИНН компании-лизингополучателя",
         "types": [
             "string"
         ],
@@ -1562,7 +1562,7 @@
     },
     {
         "path": "leasings.items[].date.event",
-        "description": "Лизинг: Дата",
+        "description": "Лизинг: Дата получения лизинга",
         "types": [
             "string"
         ],
@@ -1623,7 +1623,7 @@
     },
     {
         "path": "taxi.history.items[].license.status",
-        "description": "Такси: Статус разрешения (ACTIVE, SUSPENDED, ANNULLED, TERMINATED, UNDEFINED)",
+        "description": "Такси: Статус разрешения [ACTIVE, SUSPENDED, ANNULLED, TERMINATED, UNDEFINED]",
         "types": [
             "string"
         ],
@@ -1653,7 +1653,7 @@
     },
     {
         "path": "taxi.history.items[].ogrn",
-        "description": "Такси: ОГРН / ОГРНИП",
+        "description": "Такси: ОГРН или ОГРНИП",
         "types": [
             "string"
         ],
@@ -1663,7 +1663,7 @@
     },
     {
         "path": "taxi.history.items[].tin",
-        "description": "Такси: ИНН (Taxpayer identification number)",
+        "description": "Такси: ИНН компании или ИП (перевозчика)",
         "types": [
             "string"
         ],
@@ -1834,7 +1834,7 @@
     },
     {
         "path": "fines.items[].date.event",
-        "description": "Штрафы: Дата",
+        "description": "Штрафы: Дата регистрации штрафа",
         "types": [
             "string"
         ],
@@ -1864,7 +1864,7 @@
     },
     {
         "path": "fines.items[].description",
-        "description": "Штрафы: Короткое описание штрафа (УИН постановления, дата, сумма - в произвольном виде)",
+        "description": "Штрафы: Короткое описание штрафа (УИН постановления, дата, сумма - в произвольном формате)",
         "types": [
             "string"
         ],
@@ -1924,7 +1924,7 @@
     },
     {
         "path": "fines.items[].is_paid",
-        "description": "Штрафы: Штраф не оплачен (false) / оплачен (true)",
+        "description": "Штрафы: Оплачен ли штраф?",
         "types": [
             "boolean"
         ],
@@ -1944,7 +1944,7 @@
     },
     {
         "path": "fines.items[].wire.user.tin",
-        "description": "Штрафы: ИНН получателя",
+        "description": "Штрафы: ИНН получателя платежа",
         "types": [
             "string"
         ],
@@ -1954,7 +1954,7 @@
     },
     {
         "path": "fines.items[].wire.user.kpp",
-        "description": "Штрафы: КПП получателя",
+        "description": "Штрафы: КПП получателя платежа",
         "types": [
             "string"
         ],
@@ -2024,7 +2024,7 @@
     },
     {
         "path": "fines.has_fines",
-        "description": "Штрафы: Наличие штрафов по транспортному средству",
+        "description": "Штрафы: Имеются ли штрафы на транспортное средство?",
         "types": [
             "boolean"
         ],
@@ -2060,7 +2060,7 @@
     },
     {
         "path": "images.photos.items[].vehicle.brand.name",
-        "description": "Фотография ТС: Значение марки (бренда) ТС",
+        "description": "Фотографии ТС: Значение марки (бренда) ТС",
         "types": [
             "string"
         ],
@@ -2070,7 +2070,7 @@
     },
     {
         "path": "images.photos.items[].vehicle.model.name",
-        "description": "Фотография ТС: Значение модели ТС",
+        "description": "Фотографии ТС: Значение модели ТС",
         "types": [
             "string"
         ],
@@ -2080,7 +2080,7 @@
     },
     {
         "path": "images.photos.items[].date.issued",
-        "description": "Фотография ТС: Дата фиксации изображения",
+        "description": "Фотографии ТС: Дата фиксации изображения",
         "types": [
             "string"
         ],
@@ -2090,7 +2090,7 @@
     },
     {
         "path": "images.photos.items[].uri",
-        "description": "Фотография ТС: URI фотографии ТС",
+        "description": "Фотографии ТС: URI фотографии ТС",
         "types": [
             "string"
         ],
@@ -2100,7 +2100,7 @@
     },
     {
         "path": "car_price.items[].date.release",
-        "description": "car_price: Дата выпуска автомобиля",
+        "description": "Стоимость ТС: Дата выпуска автомобиля",
         "types": [
             "string"
         ],
@@ -2110,7 +2110,7 @@
     },
     {
         "path": "car_price.items[].amount",
-        "description": "car_price: Стоимость автомобиля",
+        "description": "Стоимость ТС: Стоимость автомобиля",
         "types": [
             "integer"
         ],
@@ -2120,7 +2120,7 @@
     },
     {
         "path": "car_price.items[].model.name",
-        "description": "car_price: Модель автомобиля",
+        "description": "Стоимость ТС: Модель автомобиля",
         "types": [
             "string"
         ],
@@ -2130,7 +2130,7 @@
     },
     {
         "path": "car_price.items[].modification.name",
-        "description": "car_price: Модификация автомобиля",
+        "description": "Стоимость ТС: Модификация автомобиля",
         "types": [
             "string"
         ],
@@ -2140,7 +2140,7 @@
     },
     {
         "path": "car_price.items[].engine.volume",
-        "description": "car_price: Объем двигателя",
+        "description": "Стоимость ТС: Объем двигателя",
         "types": [
             "float"
         ],
@@ -2150,7 +2150,7 @@
     },
     {
         "path": "car_price.items[].year",
-        "description": "car_price: Год выпуска",
+        "description": "Стоимость ТС: Год выпуска",
         "types": [
             "integer"
         ],
@@ -2190,7 +2190,7 @@
     },
     {
         "path": "repairs.history.items[].number.calculation",
-        "description": "Номер расчёта ремонтных работ",
+        "description": "Ремонтные работы: Номер расчёта ремонтных работ",
         "types": [
             "string"
         ],
@@ -2200,7 +2200,7 @@
     },
     {
         "path": "repairs.history.items[].number.claim",
-        "description": "Номер дела ремонтных работ",
+        "description": "Ремонтные работы: Номер дела ремонтных работ",
         "types": [
             "string"
         ],
@@ -2210,7 +2210,7 @@
     },
     {
         "path": "repairs.history.items[].date.calculation",
-        "description": "Дата расчета стоимости ремонтных работ",
+        "description": "Ремонтные работы: Дата расчета стоимости ремонтных работ",
         "types": [
             "string"
         ],
@@ -2220,7 +2220,7 @@
     },
     {
         "path": "repairs.history.items[].mileage",
-        "description": "Пробег",
+        "description": "Ремонтные работы: Пробег",
         "types": [
             "integer"
         ],
@@ -2230,7 +2230,7 @@
     },
     {
         "path": "repairs.history.items[].cost.total",
-        "description": "Итоговая стоимость ремонтных работ",
+        "description": "Ремонтные работы: Итоговая стоимость ремонтных работ",
         "types": [
             "integer"
         ],
@@ -2240,7 +2240,7 @@
     },
     {
         "path": "repairs.history.items[].cost.labour",
-        "description": "Стоимость выполнения ремонтных работ",
+        "description": "Ремонтные работы: Стоимость выполнения ремонтных работ",
         "types": [
             "integer"
         ],
@@ -2250,7 +2250,7 @@
     },
     {
         "path": "repairs.history.items[].cost.parts",
-        "description": "Стоимость запчастей",
+        "description": "Ремонтные работы: Стоимость запчастей",
         "types": [
             "integer"
         ],
@@ -2260,7 +2260,7 @@
     },
     {
         "path": "repairs.history.items[].cost.paint",
-        "description": "Стоимость покраски",
+        "description": "Ремонтные работы: Стоимость покраски",
         "types": [
             "integer"
         ],
@@ -2270,7 +2270,7 @@
     },
     {
         "path": "repairs.history.items[].car.manufacturer",
-        "description": "Производитель автомобиля",
+        "description": "Ремонтные работы: Производитель автомобиля",
         "types": [
             "string"
         ],
@@ -2280,7 +2280,7 @@
     },
     {
         "path": "repairs.history.items[].car.model",
-        "description": "Модель автомобиля",
+        "description": "Ремонтные работы: Модель автомобиля",
         "types": [
             "string"
         ],
@@ -2290,7 +2290,7 @@
     },
     {
         "path": "repairs.history.items[].car.sub_model",
-        "description": "Покаление автомобиля",
+        "description": "Ремонтные работы: Поколение автомобиля",
         "types": [
             "string"
         ],
@@ -2300,7 +2300,7 @@
     },
     {
         "path": "repairs.history.items[].insurer.name",
-        "description": "Название страховой компании",
+        "description": "Ремонтные работы: Название страховой компании",
         "types": [
             "string"
         ],
@@ -2310,7 +2310,7 @@
     },
     {
         "path": "repairs.history.items[].assessor.name",
-        "description": "Название компании оценщика",
+        "description": "Ремонтные работы: Название компании оценщика",
         "types": [
             "string"
         ],
@@ -2320,7 +2320,7 @@
     },
     {
         "path": "repairs.history.items[].task_process",
-        "description": "В каком процессе был выполнен расчёт? KASKO, OSAGO",
+        "description": "Ремонтные работы: В каком процессе был выполнен расчёт [KASKO, OSAGO]",
         "types": [
             "string"
         ],
@@ -2330,7 +2330,7 @@
     },
     {
         "path": "repairs.history.items[].repairer.type",
-        "description": "Тип клиента, работавшего с делом. Garage, Insurance, Assessor",
+        "description": "Ремонтные работы: Тип клиента, работавшего с делом. Garage, Insurance, Assessor",
         "types": [
             "string"
         ],
@@ -2340,7 +2340,7 @@
     },
     {
         "path": "repairs.history.items[].repairer.description",
-        "description": "Описание клиента, работавшего с делом. СТО, Страховая компания, Оценщик",
+        "description": "Ремонтные работы: Описание клиента, работавшего с делом. СТО, Страховая компания, Оценщик",
         "types": [
             "string"
         ],
@@ -2350,7 +2350,7 @@
     },
     {
         "path": "repairs.history.items[].details.items[].name",
-        "description": "Наименование ремонтных работ",
+        "description": "Ремонтные работы: Наименование ремонтных работ",
         "types": [
             "string"
         ],
@@ -2360,7 +2360,7 @@
     },
     {
         "path": "repairs.history.items[].details.items[].repair.method",
-        "description": "Код ремонтных работ",
+        "description": "Ремонтные работы: Код ремонтных работ",
         "types": [
             "string"
         ],
@@ -2370,7 +2370,7 @@
     },
     {
         "path": "repairs.history.items[].details.items[].repair.description",
-        "description": "Описание ремонтных работ",
+        "description": "Ремонтные работы: Описание ремонтных работ",
         "types": [
             "string"
         ],
@@ -2380,7 +2380,7 @@
     },
     {
         "path": "repairs.history.items[].details.count",
-        "description": "Количество позиций в списке работ",
+        "description": "Ремонтные работы: Количество позиций в списке работ",
         "types": [
             "integer"
         ],

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -446,7 +446,7 @@
     },
     {
         "path": "additional_info.vehicle.passport.number",
-        "description": "Дополнительная информация: Номер паспорта ТС (техники)",
+        "description": "Дополнительная информация: Номер паспорта ТС (ПТС)",
         "types": [
             "string"
         ],
@@ -457,7 +457,7 @@
     },
     {
         "path": "additional_info.vehicle.passport.org.name",
-        "description": "Дополнительная информация: Кто выдал паспорт ТС (техники)",
+        "description": "Дополнительная информация: Кто выдал паспорт ТС",
         "types": [
             "string"
         ],
@@ -468,7 +468,7 @@
     },
     {
         "path": "additional_info.vehicle.notes",
-        "description": "Дополнительная информация: Заметки по ТС (техники)",
+        "description": "Дополнительная информация: Заметки по ТС",
         "types": [
             "array"
         ],
@@ -499,7 +499,7 @@
     },
     {
         "path": "diagnostic_cards.items[].date.from",
-        "description": "Диагностические карты: Дата начала действия",
+        "description": "Диагностические карты: Дата начала действия диагностической карты",
         "types": [
             "string"
         ],
@@ -510,7 +510,7 @@
     },
     {
         "path": "diagnostic_cards.items[].date.to",
-        "description": "Диагностические карты: Дата окончания действия",
+        "description": "Диагностические карты: Дата окончания действия диагностической карты",
         "types": [
             "string"
         ],
@@ -697,7 +697,7 @@
     },
     {
         "path": "registration_actions.items[].geo",
-        "description": "Регистрационные действия: Гео-данные действия",
+        "description": "Регистрационные действия: Гео-данные места совершения рег. действия",
         "types": [
             "object"
         ],
@@ -994,7 +994,7 @@
     },
     {
         "path": "accidents.history.items[].geo",
-        "description": "История ДТП: Гео-данные действия",
+        "description": "История ДТП: Гео-данные места ДТП",
         "types": [
             "object"
         ],
@@ -1117,7 +1117,7 @@
     },
     {
         "path": "utilizations.items[].org.name",
-        "description": "Утилизация: Имя организации",
+        "description": "Утилизация: Наименование организации осуществившей утилизацию",
         "types": [
             "string"
         ],
@@ -1155,7 +1155,7 @@
     },
     {
         "path": "restrictions.registration_actions.items[].date.start",
-        "description": "Ограничения на рег. действия: Дата наложения ограничения",
+        "description": "Ограничения на рег. действия: Дата начала действия ограничения",
         "types": [
             "string"
         ],
@@ -1195,7 +1195,7 @@
     },
     {
         "path": "restrictions.registration_actions.items[].initiator.name",
-        "description": "Ограничения на рег. действия: Кем наложено ограничение",
+        "description": "Ограничения на рег. действия: Наименование организации наложившей ограничение",
         "types": [
             "string"
         ],
@@ -1225,7 +1225,7 @@
     },
     {
         "path": "restrictions.registration_actions.items[].restrict.reason",
-        "description": "Ограничения на рег. действия: Основания ограничения",
+        "description": "Ограничения на рег. действия: Основания для наложения ограничения",
         "types": [
             "string"
         ],
@@ -1235,7 +1235,7 @@
     },
     {
         "path": "restrictions.registration_actions.items[].restrict.number",
-        "description": "Ограничения на рег. действия: Номер документа",
+        "description": "Ограничения на рег. действия: Номер документа устанавливающего ограничения",
         "types": [
             "string"
         ],
@@ -1255,7 +1255,7 @@
     },
     {
         "path": "pledges.items[].date.event",
-        "description": "Обременения на ТС: Дата",
+        "description": "Обременения на ТС: Дата наложения обременения",
         "types": [
             "string"
         ],
@@ -1266,7 +1266,7 @@
     },
     {
         "path": "pledges.items[].number",
-        "description": "Обременения на ТС: Номер",
+        "description": "Обременения на ТС: Номер документа устанавливающего обременение",
         "types": [
             "string"
         ],
@@ -1288,7 +1288,7 @@
     },
     {
         "path": "pledges.items[].in_pledge",
-        "description": "Обременения на ТС: Состояние залога",
+        "description": "Обременения на ТС: Находится ли ТС в залоге?",
         "types": [
             "boolean"
         ],
@@ -1365,7 +1365,7 @@
     },
     {
         "path": "pledges.items[].data",
-        "description": "Обременения на ТС: Дополнительные данные",
+        "description": "Обременения на ТС: Дополнительные данные о залоге",
         "types": [
             "string",
             "array"
@@ -1377,7 +1377,7 @@
     },
     {
         "path": "customs.history.items[].date.event",
-        "description": "История по таможне: Дата прохождения таможни",
+        "description": "История по таможне: Дата получения таможенной декларации",
         "types": [
             "string"
         ],
@@ -1388,7 +1388,7 @@
     },
     {
         "path": "customs.history.items[].document.name",
-        "description": "История по таможне: Имя документа",
+        "description": "История по таможне: Наименование документа",
         "types": [
             "string"
         ],
@@ -1408,7 +1408,7 @@
     },
     {
         "path": "customs.history.items[].org.name",
-        "description": "История по таможне: Имя организации",
+        "description": "История по таможне: Наименование организации",
         "types": [
             "string"
         ],
@@ -1418,7 +1418,7 @@
     },
     {
         "path": "customs.history.items[].color.name",
-        "description": "История по таможне: Цвет",
+        "description": "История по таможне: Цвет ТС в таможенной декларации",
         "types": [
             "string"
         ],
@@ -1428,7 +1428,7 @@
     },
     {
         "path": "customs.history.items[].tax.amount",
-        "description": "История по таможне: Сумма пошлины",
+        "description": "История по таможне: Сумма таможенной пошлины",
         "types": [
             "integer"
         ],
@@ -1438,7 +1438,7 @@
     },
     {
         "path": "customs.history.items[].price.amount",
-        "description": "История по таможне: Стоимость",
+        "description": "История по таможне: Декларируемая тоимость ТС",
         "types": [
             "integer"
         ],
@@ -1449,7 +1449,7 @@
     },
     {
         "path": "customs.history.items[].mileage",
-        "description": "История по таможне: Пробег",
+        "description": "История по таможне: Пробег в таможенной декларации",
         "types": [
             "integer"
         ],
@@ -1460,7 +1460,7 @@
     },
     {
         "path": "customs.history.items[].ecology.type",
-        "description": "История по таможне: Экология",
+        "description": "История по таможне: Экологичесская норма ТС",
         "types": [
             "string"
         ],
@@ -1491,7 +1491,7 @@
     },
     {
         "path": "customs.history.items[].owner.type",
-        "description": "История по таможне: Тип владельца",
+        "description": "История по таможне: Тип владельца ТС",
         "types": [
             "string"
         ],
@@ -1501,7 +1501,7 @@
     },
     {
         "path": "customs.history.items[].owner.value",
-        "description": "История по таможне: Владелец",
+        "description": "История по таможне: Владелец ТС",
         "types": [
             "string"
         ],
@@ -1511,7 +1511,7 @@
     },
     {
         "path": "customs.history.items[].country.from.name",
-        "description": "История по таможне: Из страны (имя страны)",
+        "description": "История по таможне: Наименование страны экспортера",
         "types": [
             "string"
         ],
@@ -1522,7 +1522,7 @@
     },
     {
         "path": "customs.history.items[].country.to.name",
-        "description": "История по таможне: В страну (имя страны)",
+        "description": "История по таможне: Наименование страны импортера",
         "types": [
             "string"
         ],
@@ -1572,7 +1572,7 @@
     },
     {
         "path": "leasings.used_in_leasing",
-        "description": "Лизинг: Факт приобретения ТС в лизинг",
+        "description": "Лизинг: Приобреталось ли ТС в лизинг?",
         "types": [
             "boolean"
         ],
@@ -1633,7 +1633,7 @@
     },
     {
         "path": "taxi.history.items[].company.name",
-        "description": "Такси: Наименование компании или ИП (перевозчика)",
+        "description": "Такси: Наименование компании или ИП перевозчика",
         "types": [
             "string"
         ],
@@ -1643,7 +1643,7 @@
     },
     {
         "path": "taxi.history.items[].company.address",
-        "description": "Такси: Адрес компании или ИП (перевозчика)",
+        "description": "Такси: Адрес компании или ИП перевозчика",
         "types": [
             "string"
         ],
@@ -1653,7 +1653,7 @@
     },
     {
         "path": "taxi.history.items[].ogrn",
-        "description": "Такси: ОГРН или ОГРНИП",
+        "description": "Такси: ОГРН или ОГРНИП компании перевозчика",
         "types": [
             "string"
         ],
@@ -1663,7 +1663,7 @@
     },
     {
         "path": "taxi.history.items[].tin",
-        "description": "Такси: ИНН компании или ИП (перевозчика)",
+        "description": "Такси: ИНН компании или ИП перевозчика",
         "types": [
             "string"
         ],
@@ -1673,7 +1673,7 @@
     },
     {
         "path": "taxi.history.items[].number_plate.is_yellow",
-        "description": "Такси: Желтый ли номерной знак?",
+        "description": "Такси: Является ли номерной знак желтым (формат ГРЗ)?",
         "types": [
             "boolean"
         ],
@@ -1773,7 +1773,7 @@
     },
     {
         "path": "taxi.history.items[].region.code",
-        "description": "Такси: Код региона выдачи разрешения",
+        "description": "Такси: Код региона выдачи лицензии",
         "types": [
             "string"
         ],
@@ -1834,7 +1834,7 @@
     },
     {
         "path": "fines.items[].date.event",
-        "description": "Штрафы: Дата регистрации штрафа",
+        "description": "Штрафы: Дата инициации штрафа",
         "types": [
             "string"
         ],
@@ -1874,7 +1874,7 @@
     },
     {
         "path": "fines.items[].vendor.name",
-        "description": "Штрафы: Наименование поставщика (наименование подразделения ГИБДД)",
+        "description": "Штрафы: Наименование организации наложившей штраф (наименование подразделения ГИБДД)",
         "types": [
             "string"
         ],
@@ -2060,7 +2060,7 @@
     },
     {
         "path": "images.photos.items[].vehicle.brand.name",
-        "description": "Фотографии ТС: Значение марки (бренда) ТС",
+        "description": "Фотографии ТС: Наименование марки (бренда) ТС",
         "types": [
             "string"
         ],
@@ -2070,7 +2070,7 @@
     },
     {
         "path": "images.photos.items[].vehicle.model.name",
-        "description": "Фотографии ТС: Значение модели ТС",
+        "description": "Фотографии ТС: Наименование модели ТС",
         "types": [
             "string"
         ],
@@ -2080,7 +2080,7 @@
     },
     {
         "path": "images.photos.items[].date.issued",
-        "description": "Фотографии ТС: Дата фиксации изображения",
+        "description": "Фотографии ТС: Дата фото фиксации",
         "types": [
             "string"
         ],
@@ -2100,7 +2100,7 @@
     },
     {
         "path": "car_price.items[].date.release",
-        "description": "Стоимость ТС: Дата выпуска автомобиля",
+        "description": "Стоимость ТС: Дата выпуска ТС",
         "types": [
             "string"
         ],
@@ -2110,7 +2110,7 @@
     },
     {
         "path": "car_price.items[].amount",
-        "description": "Стоимость ТС: Стоимость автомобиля",
+        "description": "Стоимость ТС: Стоимость ТС",
         "types": [
             "integer"
         ],
@@ -2120,7 +2120,7 @@
     },
     {
         "path": "car_price.items[].model.name",
-        "description": "Стоимость ТС: Модель автомобиля",
+        "description": "Стоимость ТС: Модель ТС",
         "types": [
             "string"
         ],
@@ -2130,7 +2130,7 @@
     },
     {
         "path": "car_price.items[].modification.name",
-        "description": "Стоимость ТС: Модификация автомобиля",
+        "description": "Стоимость ТС: Модификация ТС",
         "types": [
             "string"
         ],
@@ -2140,7 +2140,7 @@
     },
     {
         "path": "car_price.items[].engine.volume",
-        "description": "Стоимость ТС: Объем двигателя",
+        "description": "Стоимость ТС: Объем двигателя ТС",
         "types": [
             "float"
         ],
@@ -2150,7 +2150,7 @@
     },
     {
         "path": "car_price.items[].year",
-        "description": "Стоимость ТС: Год выпуска",
+        "description": "Стоимость ТС: Год выпуска ТС",
         "types": [
             "integer"
         ],
@@ -2180,7 +2180,7 @@
     },
     {
         "path": "carfax.check.vehicle.model.name",
-        "description": "CarFax: Имя модели ТС",
+        "description": "CarFax: Наименование модели ТС",
         "types": [
             "string"
         ],
@@ -2190,7 +2190,7 @@
     },
     {
         "path": "repairs.history.items[].number.calculation",
-        "description": "Ремонтные работы: Номер расчёта ремонтных работ",
+        "description": "Ремонтные работы: Номер документа расчёта ремонтных работ",
         "types": [
             "string"
         ],
@@ -2220,7 +2220,7 @@
     },
     {
         "path": "repairs.history.items[].mileage",
-        "description": "Ремонтные работы: Пробег",
+        "description": "Ремонтные работы: Пробег на момент проведения ремонтных работ",
         "types": [
             "integer"
         ],
@@ -2270,7 +2270,7 @@
     },
     {
         "path": "repairs.history.items[].car.manufacturer",
-        "description": "Ремонтные работы: Производитель автомобиля",
+        "description": "Ремонтные работы: Производитель ТС",
         "types": [
             "string"
         ],
@@ -2280,7 +2280,7 @@
     },
     {
         "path": "repairs.history.items[].car.model",
-        "description": "Ремонтные работы: Модель автомобиля",
+        "description": "Ремонтные работы: Модель ТС,
         "types": [
             "string"
         ],
@@ -2290,7 +2290,7 @@
     },
     {
         "path": "repairs.history.items[].car.sub_model",
-        "description": "Ремонтные работы: Поколение автомобиля",
+        "description": "Ремонтные работы: Поколение ТС",
         "types": [
             "string"
         ],

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -8,8 +8,11 @@
         "fillable_by": [
             "base",
             "base.ext",
+            "gibdd.history",
+            "base.taxi",
+            "gibdd.eaisto",
             "base.tech",
-            "gibdd.eaisto"
+            "tech.ext"
         ]
     },
     {
@@ -21,7 +24,6 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.tech",
             "gibdd.eaisto"
         ]
     },
@@ -43,9 +45,7 @@
             "string"
         ],
         "fillable_by": [
-            "base",
             "base.ext",
-            "gibdd.eaisto",
             "gibdd.history"
         ]
     },
@@ -56,7 +56,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.eaisto"
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -65,7 +66,11 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi"
+        ]
     },
     {
         "path": "tech_data.manufacturer.name",
@@ -94,11 +99,10 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
+            "gibdd.history",
             "base.taxi",
-            "base.tech",
-            "gibdd.eaisto",
-            "gibdd.history"
+            "customs.base",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -146,8 +150,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.eaisto",
-            "gibdd.history"
+            "gibdd.history",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -169,8 +173,6 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.tech",
             "gibdd.history"
         ]
     },
@@ -183,8 +185,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.taxi",
-            "gibdd.history"
+            "gibdd.history",
+            "base.taxi"
         ]
     },
     {
@@ -196,8 +198,6 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.tech",
             "gibdd.history"
         ]
     },
@@ -221,11 +221,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.taxi",
-            "base.tech",
-            "customs.base",
             "gibdd.eaisto",
+            "base.taxi",
             "gibdd.history"
         ]
     },
@@ -235,7 +232,11 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi"
+        ]
     },
     {
         "path": "tech_data.engine.fuel.type",
@@ -256,10 +257,8 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext",
             "base.taxi",
-            "base.tech"
+            "base.ext"
         ]
     },
     {
@@ -269,9 +268,7 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext",
-            "customs.base"
+            "base.ext"
         ]
     },
     {
@@ -283,11 +280,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.taxi",
-            "base.tech",
-            "customs.base",
-            "gibdd.history"
+            "gibdd.history",
+            "base.taxi"
         ]
     },
     {
@@ -299,10 +293,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.taxi",
-            "base.tech",
-            "gibdd.history"
+            "gibdd.history",
+            "base.taxi"
         ]
     },
     {
@@ -314,8 +306,6 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.tech",
             "gibdd.history"
         ]
     },
@@ -328,9 +318,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.taxi",
-            "base.tech",
-            "gibdd.eaisto"
+            "gibdd.eaisto",
+            "base.taxi"
         ]
     },
     {
@@ -342,10 +331,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
-            "base.taxi",
-            "base.tech",
-            "gibdd.eaisto"
+            "gibdd.eaisto",
+            "base.taxi"
         ]
     },
     {
@@ -354,9 +341,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "base.tech"
-        ]
+        "fillable_by": []
     },
     {
         "path": "tech_data.drive.type",
@@ -378,8 +363,7 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.taxi",
-            "base.tech"
+            "base.taxi"
         ]
     },
     {
@@ -391,9 +375,7 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
             "base.taxi",
-            "base.tech",
             "gibdd.eaisto"
         ]
     },
@@ -406,9 +388,7 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.moscow",
             "base.taxi",
-            "base.tech",
             "gibdd.eaisto"
         ]
     },
@@ -429,7 +409,10 @@
         "types": [
             "object"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base",
+            "base.ext"
+        ]
     },
     {
         "path": "additional_info.vehicle.sts.date.receive",
@@ -438,7 +421,6 @@
             "string"
         ],
         "fillable_by": [
-            "base",
             "base.ext"
         ]
     },
@@ -449,7 +431,6 @@
             "string"
         ],
         "fillable_by": [
-            "base",
             "base.ext"
         ]
     },
@@ -460,7 +441,6 @@
             "boolean"
         ],
         "fillable_by": [
-            "base",
             "base.ext"
         ]
     },
@@ -471,9 +451,8 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext",
-            "gibdd.history"
+            "gibdd.history",
+            "base.ext"
         ]
     },
     {
@@ -483,9 +462,8 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext",
-            "gibdd.history"
+            "gibdd.history",
+            "base.ext"
         ]
     },
     {
@@ -494,7 +472,9 @@
         "types": [
             "array"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base.ext"
+        ]
     },
     {
         "path": "additional_info.identifiers.vin.checksum_validated",
@@ -512,7 +492,10 @@
         "types": [
             "boolean"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base",
+            "base.ext"
+        ]
     },
     {
         "path": "diagnostic_cards.items[].date.from",
@@ -521,9 +504,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
             "gibdd.eaisto",
-            "tech.base",
             "tech.ext"
         ]
     },
@@ -534,9 +515,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
             "gibdd.eaisto",
-            "tech.base",
             "tech.ext"
         ]
     },
@@ -547,6 +526,7 @@
             "string"
         ],
         "fillable_by": [
+            "gibdd.eaisto",
             "tech.ext"
         ]
     },
@@ -557,9 +537,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
             "gibdd.eaisto",
-            "tech.base",
             "tech.ext"
         ]
     },
@@ -571,7 +549,6 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "tech.base",
             "tech.ext"
         ]
     },
@@ -582,7 +559,8 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow"
+            "gibdd.eaisto",
+            "tech.ext"
         ]
     },
     {
@@ -593,7 +571,6 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "tech.base",
             "tech.ext"
         ]
     },
@@ -604,7 +581,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
             "gibdd.history"
         ]
     },
@@ -615,7 +591,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
             "gibdd.history"
         ]
     },
@@ -626,7 +601,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
             "gibdd.history"
         ]
     },
@@ -651,8 +625,7 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.taxi",
-            "base.tech"
+            "base.taxi"
         ]
     },
     {
@@ -673,7 +646,6 @@
             "string"
         ],
         "fillable_by": [
-            "base",
             "base.ext"
         ]
     },
@@ -697,8 +669,7 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.taxi",
-            "base.tech"
+            "base.taxi"
         ]
     },
     {
@@ -708,8 +679,8 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext"
+            "base.ext",
+            "base.taxi"
         ]
     },
     {
@@ -719,10 +690,9 @@
             "string"
         ],
         "fillable_by": [
-            "base",
             "base.ext",
-            "base.taxi",
-            "base.tech"
+            "base",
+            "base.taxi"
         ]
     },
     {
@@ -731,7 +701,11 @@
         "types": [
             "object"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi"
+        ]
     },
     {
         "path": "insurance.osago.items[].number",
@@ -760,7 +734,6 @@
             "string"
         ],
         "fillable_by": [
-            "ramiosago.base"
         ]
     },
     {
@@ -770,7 +743,6 @@
             "string"
         ],
         "fillable_by": [
-            "ramiosago.base"
         ]
     },
     {
@@ -957,8 +929,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
-            "base.tech",
             "gibdd.dtp"
         ]
     },
@@ -969,8 +939,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
-            "base.tech",
             "gibdd.dtp"
         ]
     },
@@ -1030,7 +998,9 @@
         "types": [
             "object"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "gibdd.dtp"
+        ]
     },
     {
         "path": "accidents.history.items[].damage.points",
@@ -1038,7 +1008,9 @@
         "types": [
             "array"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "gibdd.dtp"
+        ]
     },
     {
         "path": "accidents.history.items[].damage.raw",
@@ -1046,7 +1018,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base.moscow"
+        ]
     },
     {
         "path": "accidents.insurance.items[].date.event",
@@ -1084,7 +1058,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "base.moscow"
+        ]
     },
     {
         "path": "accidents.has_accidents",
@@ -1093,8 +1069,8 @@
             "boolean"
         ],
         "fillable_by": [
-            "base.moscow",
-            "base.tech"
+            "gibdd.dtp",
+            "base.moscow"
         ]
     },
     {
@@ -1113,7 +1089,9 @@
         "types": [
             "object"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "gibdd.wanted"
+        ]
     },
     {
         "path": "stealings.is_wanted",
@@ -1122,7 +1100,8 @@
             "boolean"
         ],
         "fillable_by": [
-            "base.moscow"
+            "gibdd.wanted",
+            "base.taxi"
         ]
     },
     {
@@ -1159,7 +1138,8 @@
             "boolean"
         ],
         "fillable_by": [
-            "base.moscow",
+            "base",
+            "base.ext",
             "base.taxi"
         ]
     },
@@ -1189,7 +1169,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "gibdd.restrict"
+        ]
     },
     {
         "path": "restrictions.registration_actions.items[].vehicle.year",
@@ -1268,7 +1250,7 @@
             "boolean"
         ],
         "fillable_by": [
-            "base.moscow"
+            "gibdd.restrict"
         ]
     },
     {
@@ -1321,7 +1303,10 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "pledges.items[].pledgors[].type",
@@ -1329,7 +1314,10 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "pledges.items[].pledgors[].dob",
@@ -1337,7 +1325,10 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "pledges.items[].pledgees[].name",
@@ -1345,7 +1336,10 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "pledges.items[].pledgees[].type",
@@ -1353,7 +1347,10 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "pledges.items[].pledgees[].dob",
@@ -1361,7 +1358,10 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "pledges.items[].data",
@@ -1370,7 +1370,10 @@
             "string",
             "array"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
+        ]
     },
     {
         "path": "customs.history.items[].date.event",
@@ -1379,9 +1382,8 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi",
-            "base.tech",
-            "customs.base"
+            "customs.base",
+            "base.tech"
         ]
     },
     {
@@ -1390,7 +1392,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "customs.base"
+        ]
     },
     {
         "path": "customs.history.items[].document.number",
@@ -1399,7 +1403,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi",
             "customs.base"
         ]
     },
@@ -1410,7 +1413,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi",
             "customs.base"
         ]
     },
@@ -1421,7 +1423,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi"
+            "customs.base"
         ]
     },
     {
@@ -1430,7 +1432,9 @@
         "types": [
             "integer"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "customs.base"
+        ]
     },
     {
         "path": "customs.history.items[].price.amount",
@@ -1439,9 +1443,8 @@
             "integer"
         ],
         "fillable_by": [
-            "base.taxi",
-            "base.tech",
-            "customs.base"
+            "customs.base",
+            "base.tech"
         ]
     },
     {
@@ -1451,7 +1454,8 @@
             "integer"
         ],
         "fillable_by": [
-            "customs.base"
+            "customs.base",
+            "base.tech"
         ]
     },
     {
@@ -1461,7 +1465,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi",
             "customs.base"
         ]
     },
@@ -1472,6 +1475,7 @@
             "string"
         ],
         "fillable_by": [
+            "customs.base",
             "base.tech"
         ]
     },
@@ -1492,7 +1496,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi"
+            "customs.base"
         ]
     },
     {
@@ -1501,7 +1505,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "customs.base"
+        ]
     },
     {
         "path": "customs.history.items[].country.from.name",
@@ -1510,9 +1516,8 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi",
-            "base.tech",
-            "customs.base"
+            "customs.base",
+            "base.tech"
         ]
     },
     {
@@ -1522,7 +1527,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi"
+            "customs.base"
         ]
     },
     {
@@ -1532,7 +1537,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi"
+            "base.ext"
         ]
     },
     {
@@ -1542,9 +1547,7 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext",
-            "base.taxi"
+            "base.ext"
         ]
     },
     {
@@ -1554,7 +1557,6 @@
             "string"
         ],
         "fillable_by": [
-            "base",
             "base.ext"
         ]
     },
@@ -1565,9 +1567,7 @@
             "string"
         ],
         "fillable_by": [
-            "base",
-            "base.ext",
-            "base.taxi"
+            "base.ext"
         ]
     },
     {
@@ -1577,6 +1577,7 @@
             "boolean"
         ],
         "fillable_by": [
+            "base.ext",
             "base.taxi"
         ]
     },
@@ -1587,9 +1588,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "base.taxi",
-            "base.tech"
+            "av.taxi"
         ]
     },
     {
@@ -1599,8 +1598,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "base.tech"
+            "av.taxi"
         ]
     },
     {
@@ -1640,9 +1638,7 @@
             "string"
         ],
         "fillable_by": [
-            "av.taxi",
-            "base.taxi",
-            "base.tech"
+            "av.taxi"
         ]
     },
     {
@@ -1651,7 +1647,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "av.taxi"
+        ]
     },
     {
         "path": "taxi.history.items[].ogrn",
@@ -1670,7 +1668,6 @@
             "string"
         ],
         "fillable_by": [
-            "base.taxi",
             "av.taxi"
         ]
     },
@@ -1680,7 +1677,9 @@
         "types": [
             "boolean"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "av.taxi"
+        ]
     },
     {
         "path": "taxi.history.items[].vehicle.brand.name",
@@ -1728,7 +1727,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "av.taxi"
+        ]
     },
     {
         "path": "taxi.history.items[].vehicle.reg_num",
@@ -1786,7 +1787,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "av.taxi"
+        ]
     },
     {
         "path": "taxi.history.items[].cancel.note",
@@ -1794,7 +1797,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "av.taxi"
+        ]
     },
     {
         "path": "taxi.history.items[].permit.number",
@@ -1824,9 +1829,7 @@
         ],
         "fillable_by": [
             "av.taxi",
-            "base.moscow",
-            "base.taxi",
-            "base.tech"
+            "base.taxi"
         ]
     },
     {
@@ -2036,11 +2039,10 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow",
-            "base.taxi",
-            "base.tech",
             "gibdd.eaisto",
-            "tech.ext"
+            "tech.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -2050,11 +2052,10 @@
             "integer"
         ],
         "fillable_by": [
-            "base.moscow",
-            "base.taxi",
-            "base.tech",
             "gibdd.eaisto",
-            "tech.ext"
+            "tech.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -2103,7 +2104,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "carprice"
+        ]
     },
     {
         "path": "car_price.items[].amount",
@@ -2112,7 +2115,6 @@
             "integer"
         ],
         "fillable_by": [
-            "base.moscow",
             "carprice"
         ]
     },

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -4,6 +4,12 @@
         "description": "Идентификатор ТС: VIN",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.tech",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -11,6 +17,12 @@
         "description": "Идентификатор ТС: ГРЗ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.tech",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -18,6 +30,10 @@
         "description": "Идентификатор ТС: СТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -25,6 +41,12 @@
         "description": "Идентификатор ТС: ПТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "gibdd.eaisto",
+            "gibdd.history"
         ]
     },
     {
@@ -32,6 +54,9 @@
         "description": "Идентификатор ТС: Номер кузова",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.eaisto"
         ]
     },
     {
@@ -53,6 +78,9 @@
         "description": "Характеристики ТС: Уникальный идентификатор марки",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "references.base"
         ]
     },
     {
@@ -60,6 +88,15 @@
         "description": "Характеристики ТС: Марка",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto",
+            "gibdd.history"
         ]
     },
     {
@@ -67,6 +104,9 @@
         "description": "Характеристики ТС: Нормализованное значение марки",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "references.base"
         ]
     },
     {
@@ -81,6 +121,9 @@
         "description": "Характеристики ТС: URI логотипа марки ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "references.base"
         ]
     },
     {
@@ -88,6 +131,9 @@
         "description": "Характеристики ТС: Уникальный идентификатор модель",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "references.base"
         ]
     },
     {
@@ -95,6 +141,10 @@
         "description": "Характеристики ТС: Модель",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.eaisto",
+            "gibdd.history"
         ]
     },
     {
@@ -102,6 +152,9 @@
         "description": "Характеристики ТС: Нормализованное значение модели",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "references.base"
         ]
     },
     {
@@ -109,6 +162,13 @@
         "description": "Характеристики ТС: Тип (Вид) ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.tech",
+            "gibdd.history"
         ]
     },
     {
@@ -116,6 +176,12 @@
         "description": "Характеристики ТС: Номер Кузова",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "gibdd.history"
         ]
     },
     {
@@ -123,6 +189,13 @@
         "description": "Характеристики ТС: Цвет",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.tech",
+            "gibdd.history"
         ]
     },
     {
@@ -130,6 +203,10 @@
         "description": "Характеристики ТС: Тип цвета",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -137,6 +214,16 @@
         "description": "Характеристики ТС: Год выпуска",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "customs.base",
+            "gibdd.eaisto",
+            "gibdd.history"
         ]
     },
     {
@@ -151,6 +238,11 @@
         "description": "Характеристики ТС: Тип топлива",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "customs.base"
         ]
     },
     {
@@ -158,6 +250,12 @@
         "description": "Характеристики ТС: Номер двигателя",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -165,6 +263,11 @@
         "description": "Характеристики ТС: Модель двигателя",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "customs.base"
         ]
     },
     {
@@ -172,6 +275,15 @@
         "description": "Характеристики ТС: Объем двигателя",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "customs.base",
+            "gibdd.history"
         ]
     },
     {
@@ -179,6 +291,14 @@
         "description": "Характеристики ТС: Мощность в ЛС",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.history"
         ]
     },
     {
@@ -186,6 +306,13 @@
         "description": "Характеристики ТС: Мощность в кВ",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.tech",
+            "gibdd.history"
         ]
     },
     {
@@ -193,6 +320,13 @@
         "description": "Характеристики ТС: Масса без нагрузки",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -200,6 +334,14 @@
         "description": "Характеристики ТС: Разрешенная макс. масса",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -207,6 +349,9 @@
         "description": "Характеристики ТС: Трансмиссия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.tech"
         ]
     },
     {
@@ -214,6 +359,10 @@
         "description": "Характеристики ТС: Тип привода",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -221,6 +370,12 @@
         "description": "Характеристики ТС: Расположение руля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -228,6 +383,14 @@
         "description": "Дополнительная информация: Код категории ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -235,6 +398,14 @@
         "description": "Дополнительная информация: Описание категории ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto"
         ]
     },
     {
@@ -242,6 +413,10 @@
         "description": "Дополнительная информация: Тип владельца (техники)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -256,6 +431,10 @@
         "description": "Дополнительная информация: Дата выдачи СТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -263,6 +442,10 @@
         "description": "Дополнительная информация: Дата выдачи паспорта ТС (техники)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -270,6 +453,10 @@
         "description": "Дополнительная информация: Была ли замена ПТС?",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -277,6 +464,11 @@
         "description": "Дополнительная информация: Номер паспорта ТС (техники)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "gibdd.history"
         ]
     },
     {
@@ -284,6 +476,11 @@
         "description": "Дополнительная информация: Кто выдал паспорт ТС (техники)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "gibdd.history"
         ]
     },
     {
@@ -298,6 +495,9 @@
         "description": "Дополнительная информация: Проверка контрольного символа VIN",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base.tech"
         ]
     },
     {
@@ -312,6 +512,12 @@
         "description": "Диагностические карты: Дата начала",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "gibdd.eaisto",
+            "tech.base",
+            "tech.ext"
         ]
     },
     {
@@ -319,6 +525,12 @@
         "description": "Диагностические карты: Дата ПО",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "gibdd.eaisto",
+            "tech.base",
+            "tech.ext"
         ]
     },
     {
@@ -326,6 +538,9 @@
         "description": "Диагностические карты: Серия документа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "tech.ext"
         ]
     },
     {
@@ -333,6 +548,12 @@
         "description": "Диагностические карты: Номер документа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "gibdd.eaisto",
+            "tech.base",
+            "tech.ext"
         ]
     },
     {
@@ -340,6 +561,11 @@
         "description": "Диагностические карты: Тип документа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.eaisto",
+            "tech.base",
+            "tech.ext"
         ]
     },
     {
@@ -347,6 +573,9 @@
         "description": "Диагностические карты: Место прохождения проверки",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -354,6 +583,11 @@
         "description": "Диагностические карты: ГРЗ знак",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.eaisto",
+            "tech.base",
+            "tech.ext"
         ]
     },
     {
@@ -361,6 +595,10 @@
         "description": "История владения: Дата начала владения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "gibdd.history"
         ]
     },
     {
@@ -368,6 +606,10 @@
         "description": "История владения: Дата окончания владения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "gibdd.history"
         ]
     },
     {
@@ -375,6 +617,10 @@
         "description": "История владения: Тип владельца",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "gibdd.history"
         ]
     },
     {
@@ -382,6 +628,11 @@
         "description": "Регистрационные действия: Дата начала рег. действия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi"
         ]
     },
     {
@@ -389,6 +640,12 @@
         "description": "Регистрационные действия: Дата окончания рег. действия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -396,6 +653,10 @@
         "description": "Регистрационные действия: ГРЗ знак",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -403,6 +664,10 @@
         "description": "Регистрационные действия: Номер ПТС (паспорт ТС)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -410,6 +675,10 @@
         "description": "Регистрационные действия: Номер СТС (свидетельства регистрации ТС)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -417,6 +686,12 @@
         "description": "Регистрационные действия: Тип владельца",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -424,6 +699,10 @@
         "description": "Регистрационные действия: Наименование предприятия-владельца",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -431,6 +710,12 @@
         "description": "Регистрационные действия: Тип операции",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -445,6 +730,9 @@
         "description": "ОСАГО: Номер договора",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -452,6 +740,9 @@
         "description": "ОСАГО: Страховщик",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -459,6 +750,9 @@
         "description": "ОСАГО: Дата начала",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -466,6 +760,9 @@
         "description": "ОСАГО: Дата окончания",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -473,6 +770,9 @@
         "description": "ОСАГО: Ограничения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -480,6 +780,9 @@
         "description": "ОСАГО: Серия полиса",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -487,6 +790,9 @@
         "description": "ОСАГО: Номер полиса",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "ramiosago.base"
         ]
     },
     {
@@ -508,6 +814,10 @@
         "description": "Калькулятор ОСАГО: Региональный коэффициент ОСАГО",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -515,6 +825,9 @@
         "description": "Калькулятор ОСАГО: Имя региона регистрации ТС (автоматически определенный)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -522,6 +835,9 @@
         "description": "Калькулятор ОСАГО: Имя города регистрации ТС (автоматически определенный)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -529,6 +845,9 @@
         "description": "Калькулятор ОСАГО: Приблизительная стоимость ОСАГО за 12 месяцев (для автоматически определенного региона регистрации ТС)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -536,6 +855,9 @@
         "description": "Калькулятор ОСАГО: Мин сумма ОСАГО для регионов",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -543,6 +865,9 @@
         "description": "Калькулятор ОСАГО: Макс сумма ОСАГО для регионов",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -550,6 +875,9 @@
         "description": "Калькулятор ОСАГО: Приблизительная стоимость ОСАГО за 12 месяцев (для Москвы)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -557,6 +885,9 @@
         "description": "Калькулятор ОСАГО: Минимальная стоимость ОСАГО 12 мес. (для Москвы)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -564,6 +895,9 @@
         "description": "Калькулятор ОСАГО: Максимальная стоимость ОСАГО 12 мес. (для Москвы)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -571,6 +905,9 @@
         "description": "Калькулятор ОСАГО: Приблизительная стоимость ОСАГО за 12 месяцев (для Московской Области)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -578,6 +915,9 @@
         "description": "Калькулятор ОСАГО: Мин ОСАГО 12 мес. (для Московской Области)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -585,6 +925,9 @@
         "description": "Калькулятор ОСАГО: Макс стоимость ОСАГО 12 мес. (для Московской Области)",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "calc.osago"
         ]
     },
     {
@@ -592,6 +935,9 @@
         "description": "История ДТП: Номер происшествия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.dtp"
         ]
     },
     {
@@ -599,6 +945,11 @@
         "description": "История ДТП: Дата происшествия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "base.tech",
+            "gibdd.dtp"
         ]
     },
     {
@@ -606,6 +957,11 @@
         "description": "История ДТП: Тип происшествия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "base.tech",
+            "gibdd.dtp"
         ]
     },
     {
@@ -613,6 +969,9 @@
         "description": "История ДТП: Статус ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.dtp"
         ]
     },
     {
@@ -620,6 +979,9 @@
         "description": "История ДТП: Организация, которая провела регистрацию ДТП",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -627,6 +989,9 @@
         "description": "История ДТП: Марка ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.dtp"
         ]
     },
     {
@@ -634,6 +999,9 @@
         "description": "История ДТП: Модель ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.dtp"
         ]
     },
     {
@@ -641,6 +1009,9 @@
         "description": "История ДТП: Год выпуска ТС",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "gibdd.dtp"
         ]
     },
     {
@@ -669,6 +1040,9 @@
         "description": "История повреждений из страховых компаний: Дата происшествия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -676,6 +1050,9 @@
         "description": "История повреждений из страховых компаний: Тип страхования (ОСАГО, КАСКО)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -683,6 +1060,9 @@
         "description": "История повреждений из страховых компаний: Тип происшествия",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -697,6 +1077,10 @@
         "description": "История ДТП: Наличие у ТС ДТП по данным ГИБДД и страховых компаний",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "base.tech"
         ]
     },
     {
@@ -704,6 +1088,9 @@
         "description": "Проверка на угон: Дата угона",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.wanted"
         ]
     },
     {
@@ -718,6 +1105,9 @@
         "description": "Проверка на угон: ТС находится в розыске?",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -725,6 +1115,10 @@
         "description": "Утилизация: Дата утилизации",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -746,6 +1140,10 @@
         "description": "Утилизация: Было ли ТС утилизировано?",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "base.taxi"
         ]
     },
     {
@@ -753,6 +1151,9 @@
         "description": "Ограничения на рег. действия: Дата добавления данных об ограничении в реестр",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -760,6 +1161,9 @@
         "description": "Ограничения на рег. действия: Дата наложения ограничения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -774,6 +1178,9 @@
         "description": "Ограничения на рег. действия: Год выпуска ТС",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -781,6 +1188,9 @@
         "description": "Ограничения на рег. действия: Марка (модель) ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -788,6 +1198,9 @@
         "description": "Ограничения на рег. действия: Кем наложено ограничение",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -795,6 +1208,9 @@
         "description": "Ограничения на рег. действия: Регион инициатора ограничения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -802,6 +1218,9 @@
         "description": "Ограничения на рег. действия: Вид ограничения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -809,6 +1228,9 @@
         "description": "Ограничения на рег. действия: Основания ограничения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -816,6 +1238,9 @@
         "description": "Ограничения на рег. действия: Номер документа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "gibdd.restrict"
         ]
     },
     {
@@ -823,6 +1248,9 @@
         "description": "Ограничения на рег. действия: Имеются ли ограничения на рег. действия?",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base.moscow"
         ]
     },
     {
@@ -830,6 +1258,10 @@
         "description": "Обременения на ТС: Дата",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
         ]
     },
     {
@@ -837,6 +1269,10 @@
         "description": "Обременения на ТС: Номер",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
         ]
     },
     {
@@ -844,6 +1280,10 @@
         "description": "Обременения на ТС: Тип события (возникновение, исключение, прочее)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
         ]
     },
     {
@@ -851,6 +1291,10 @@
         "description": "Обременения на ТС: Состояние залога",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "pledge",
+            "pledge.house"
         ]
     },
     {
@@ -908,6 +1352,11 @@
         "description": "История по таможне: Дата",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "base.tech",
+            "customs.base"
         ]
     },
     {
@@ -922,6 +1371,10 @@
         "description": "История по таможне: Номер документа (декларации)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "customs.base"
         ]
     },
     {
@@ -929,6 +1382,10 @@
         "description": "История по таможне: Имя организации",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "customs.base"
         ]
     },
     {
@@ -936,6 +1393,9 @@
         "description": "История по таможне: Цвет",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi"
         ]
     },
     {
@@ -950,6 +1410,11 @@
         "description": "История по таможне: Стоимость",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "base.tech",
+            "customs.base"
         ]
     },
     {
@@ -957,6 +1422,9 @@
         "description": "История по таможне: Пробег",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "customs.base"
         ]
     },
     {
@@ -964,6 +1432,10 @@
         "description": "История по таможне: Экология",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "customs.base"
         ]
     },
     {
@@ -971,6 +1443,9 @@
         "description": "История по таможне: Спецификация",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.tech"
         ]
     },
     {
@@ -978,6 +1453,9 @@
         "description": "История по таможне: Спецификация, сырая строка",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "customs.base"
         ]
     },
     {
@@ -985,6 +1463,9 @@
         "description": "История по таможне: Тип владельца",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi"
         ]
     },
     {
@@ -999,6 +1480,11 @@
         "description": "История по таможне: Из страны (имя страны)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "base.tech",
+            "customs.base"
         ]
     },
     {
@@ -1006,6 +1492,9 @@
         "description": "История по таможне: В страну (имя страны)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi"
         ]
     },
     {
@@ -1013,6 +1502,9 @@
         "description": "Лизинг: ИНН (Taxpayer identification number)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi"
         ]
     },
     {
@@ -1020,6 +1512,11 @@
         "description": "Лизинг: Наименование компании-лизингополучателя",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi"
         ]
     },
     {
@@ -1027,6 +1524,10 @@
         "description": "Лизинг: Наименование компании-лизингодателя",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext"
         ]
     },
     {
@@ -1034,6 +1535,11 @@
         "description": "Лизинг: Дата",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base",
+            "base.ext",
+            "base.taxi"
         ]
     },
     {
@@ -1041,6 +1547,9 @@
         "description": "Лизинг: Факт приобретения ТС в лизинг",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "base.taxi"
         ]
     },
     {
@@ -1048,6 +1557,12 @@
         "description": "Такси: Дата начала эксплуатации ТС в качестве такси",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "base.taxi",
+            "base.tech",
+            "taxi.registry"
         ]
     },
     {
@@ -1055,6 +1570,11 @@
         "description": "Такси: Дата окончания эксплуатации ТС в качестве такси",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "base.tech",
+            "taxi.registry"
         ]
     },
     {
@@ -1062,6 +1582,10 @@
         "description": "Такси: Регистрационный номер разрешения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1069,6 +1593,9 @@
         "description": "Такси: Дата выдачи разрешения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1076,6 +1603,9 @@
         "description": "Такси: Статус разрешения (ACTIVE, SUSPENDED, ANNULLED, TERMINATED, UNDEFINED)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1083,6 +1613,12 @@
         "description": "Такси: Наименование компании или ИП (перевозчика)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "base.taxi",
+            "base.tech",
+            "taxi.registry"
         ]
     },
     {
@@ -1097,6 +1633,10 @@
         "description": "Такси: ОГРН / ОГРНИП",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1104,6 +1644,10 @@
         "description": "Такси: ИНН (Taxpayer identification number)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1118,6 +1662,10 @@
         "description": "Такси: Марка автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1125,6 +1673,9 @@
         "description": "Такси: Нормализованное значение марки автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1132,6 +1683,10 @@
         "description": "Такси: Модель автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1139,6 +1694,9 @@
         "description": "Такси: Нормализованное значение модели автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1153,6 +1711,10 @@
         "description": "Такси: Государственный регистрационный знак",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1160,6 +1722,10 @@
         "description": "Такси: Год выпуска автомобиля",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1167,6 +1733,9 @@
         "description": "Такси: Номер СТС (свидетельства регистрации ТС)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1174,6 +1743,9 @@
         "description": "Такси: Дата получения СТС (свидетельства регистрации ТС)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1181,6 +1753,9 @@
         "description": "Такси: Код региона выдачи разрешения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "taxi.registry"
         ]
     },
     {
@@ -1202,6 +1777,10 @@
         "description": "Такси: Серия и номер бланка разрешения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1209,6 +1788,10 @@
         "description": "Такси: Город регистрации",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "taxi.registry"
         ]
     },
     {
@@ -1216,6 +1799,12 @@
         "description": "Такси: Использовалось ли ТС в качестве такси?",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "av.taxi",
+            "base.moscow",
+            "base.taxi",
+            "base.tech"
         ]
     },
     {
@@ -1223,6 +1812,9 @@
         "description": "Штрафы: Дата",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1230,6 +1822,9 @@
         "description": "Штрафы: Статья правонарушения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1237,6 +1832,9 @@
         "description": "Штрафы: Описание статьи правонарушения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1244,6 +1842,9 @@
         "description": "Штрафы: Короткое описание штрафа (УИН постановления, дата, сумма - в произвольном виде)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1251,6 +1852,9 @@
         "description": "Штрафы: Наименование поставщика (наименование подразделения ГИБДД)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1258,6 +1862,9 @@
         "description": "Штрафы: Сумма штрафа",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1265,6 +1872,9 @@
         "description": "Штрафы: Общая сумма начисления",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1272,6 +1882,9 @@
         "description": "Штрафы: Размер скидки в %",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1279,6 +1892,9 @@
         "description": "Штрафы: Дата действия скидки по оплате",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1286,6 +1902,9 @@
         "description": "Штрафы: Штраф не оплачен (false) / оплачен (true)",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1293,6 +1912,9 @@
         "description": "Штрафы: Наименование получателя платежа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1300,6 +1922,9 @@
         "description": "Штрафы: ИНН получателя",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1307,6 +1932,9 @@
         "description": "Штрафы: КПП получателя",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1314,6 +1942,9 @@
         "description": "Штрафы: Номер счета получателя платежа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1321,6 +1952,9 @@
         "description": "Штрафы: Наименование банка получателя платежа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1328,6 +1962,9 @@
         "description": "Штрафы: БИК банка получателя платежа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1335,6 +1972,9 @@
         "description": "Штрафы: Назначение платежа",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1342,6 +1982,9 @@
         "description": "Штрафы: КБК",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1349,6 +1992,9 @@
         "description": "Штрафы: ОКТМО (ОКАТО)",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1356,6 +2002,9 @@
         "description": "Штрафы: Наличие штрафов по транспортному средству",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "fines.base"
         ]
     },
     {
@@ -1363,6 +2012,13 @@
         "description": "Пробеги: Дата фиксирования пробега",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto",
+            "tech.ext"
         ]
     },
     {
@@ -1370,6 +2026,13 @@
         "description": "Пробеги: Значение пробега",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "base.taxi",
+            "base.tech",
+            "gibdd.eaisto",
+            "tech.ext"
         ]
     },
     {
@@ -1377,6 +2040,9 @@
         "description": "Фотография ТС: Значение марки (бренда) ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "images.avtonomer"
         ]
     },
     {
@@ -1384,6 +2050,9 @@
         "description": "Фотография ТС: Значение модели ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "images.avtonomer"
         ]
     },
     {
@@ -1391,6 +2060,9 @@
         "description": "Фотография ТС: Дата фиксации изображения",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "images.avtonomer"
         ]
     },
     {
@@ -1398,6 +2070,9 @@
         "description": "Фотография ТС: URI фотографии ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "images.avtonomer"
         ]
     },
     {
@@ -1412,6 +2087,10 @@
         "description": "car_price: Стоимость автомобиля",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "base.moscow",
+            "carprice"
         ]
     },
     {
@@ -1419,6 +2098,9 @@
         "description": "car_price: Модель автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "carprice"
         ]
     },
     {
@@ -1426,6 +2108,9 @@
         "description": "car_price: Модификация автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "carprice"
         ]
     },
     {
@@ -1433,6 +2118,9 @@
         "description": "car_price: Объем двигателя",
         "types": [
             "float"
+        ],
+        "fillable_by": [
+            "carprice"
         ]
     },
     {
@@ -1440,6 +2128,9 @@
         "description": "car_price: Год выпуска",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "carprice"
         ]
     },
     {
@@ -1447,6 +2138,9 @@
         "description": "CarFax: Существуют ли данные у сервиса CarFax?",
         "types": [
             "boolean"
+        ],
+        "fillable_by": [
+            "carfax.check"
         ]
     },
     {
@@ -1454,6 +2148,9 @@
         "description": "CarFax: Количество найденных записей",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "carfax.check"
         ]
     },
     {
@@ -1461,6 +2158,9 @@
         "description": "CarFax: Имя модели ТС",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "carfax.check"
         ]
     },
     {
@@ -1468,6 +2168,9 @@
         "description": "Номер расчёта ремонтных работ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1475,6 +2178,9 @@
         "description": "Номер дела ремонтных работ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1482,6 +2188,9 @@
         "description": "Дата расчета стоимости ремонтных работ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1489,6 +2198,9 @@
         "description": "Пробег",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1496,6 +2208,9 @@
         "description": "Итоговая стоимость ремонтных работ",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1503,6 +2218,9 @@
         "description": "Стоимость выполнения ремонтных работ",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1510,6 +2228,9 @@
         "description": "Стоимость запчастей",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1517,6 +2238,9 @@
         "description": "Стоимость покраски",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1524,6 +2248,9 @@
         "description": "Производитель автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1531,6 +2258,9 @@
         "description": "Модель автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1538,6 +2268,9 @@
         "description": "Покаление автомобиля",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1545,6 +2278,9 @@
         "description": "Название страховой компании",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1552,6 +2288,9 @@
         "description": "Название компании оценщика",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1559,6 +2298,9 @@
         "description": "В каком процессе был выполнен расчёт? KASKO, OSAGO",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1566,6 +2308,9 @@
         "description": "Тип клиента, работавшего с делом. Garage, Insurance, Assessor",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1573,6 +2318,9 @@
         "description": "Описание клиента, работавшего с делом. СТО, Страховая компания, Оценщик",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1580,6 +2328,9 @@
         "description": "Наименование ремонтных работ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1587,6 +2338,9 @@
         "description": "Код ремонтных работ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1594,6 +2348,9 @@
         "description": "Описание ремонтных работ",
         "types": [
             "string"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     },
     {
@@ -1601,6 +2358,9 @@
         "description": "Количество позиций в списке работ",
         "types": [
             "integer"
+        ],
+        "fillable_by": [
+            "repairs.history"
         ]
     }
 ]

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -2280,7 +2280,7 @@
     },
     {
         "path": "repairs.history.items[].car.model",
-        "description": "Ремонтные работы: Модель ТС,
+        "description": "Ремонтные работы: Модель ТС",
         "types": [
             "string"
         ],

--- a/sdk/php/src/Specifications.php
+++ b/sdk/php/src/Specifications.php
@@ -31,7 +31,7 @@ class Specifications
      */
     public static function getRootDirectoryPath(string $additional_path = null): string
     {
-        $root = \dirname(\dirname(\dirname(__DIR__))); // `dirname()` reason - https://git.io/vhXvr
+        $root = \dirname(__DIR__, 3);
 
         return $additional_path !== null
             ? $root . DIRECTORY_SEPARATOR . ltrim($additional_path, ' \\/')

--- a/sdk/php/src/Structures/Field.php
+++ b/sdk/php/src/Structures/Field.php
@@ -38,6 +38,13 @@ class Field extends AbstractStructure
     protected $types = [];
 
     /**
+     * Possible sources.
+     *
+     * @var string[]|array
+     */
+    protected $fillable_by = [];
+
+    /**
      * {@inheritdoc}
      */
     public function toArray()
@@ -46,6 +53,7 @@ class Field extends AbstractStructure
             'path'        => $this->path,
             'description' => $this->description,
             'types'       => $this->types,
+            'fillable_by' => $this->fillable_by,
         ];
     }
 
@@ -90,6 +98,14 @@ class Field extends AbstractStructure
     }
 
     /**
+     * Get possible sources.
+     */
+    public function getFillableBy()
+    {
+        return $this->fillable_by;
+    }
+
+    /**
      * Get field nesting depth.
      *
      * @return int
@@ -131,6 +147,12 @@ class Field extends AbstractStructure
 
                     case 'types':
                         $this->types = $value === null
+                            ? null
+                            : (array) $value;
+                        break;
+
+                    case 'fillable_by':
+                        $this->fillable_by = $value === null
                             ? null
                             : (array) $value;
                         break;

--- a/sdk/php/src/Structures/Field.php
+++ b/sdk/php/src/Structures/Field.php
@@ -99,6 +99,8 @@ class Field extends AbstractStructure
 
     /**
      * Get possible sources.
+     *
+     * @return array|string[]
      */
     public function getFillableBy()
     {

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -91,7 +91,7 @@ class SpecificationsTest extends AbstractTestCase
                     "{$path} has no 'fillable_by' attribute"
                 );
 
-                $this->assertInternalType(IsType::TYPE_ARRAY, $fillable_by);
+                $this->assertInternalType('array', $fillable_by);
 
                 // @todo: uncomment below after review
                 // $this->assertNotEmpty($fillable_by, "Path {$path} has empty 'fillable_by' attribute");

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -57,6 +57,18 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetFieldsSpecification()
     {
+        $fillable_by_should_be_empty_for = [
+            'tech_data.manufacturer.name',
+            'tech_data.brand.name.rus',
+            'tech_data.transmission.type',
+            'insurance.osago.items[].date.start',
+            'insurance.osago.items[].date.end',
+            'calculate.tax.moscow.yearly.amount',
+            'calculate.tax.regions.yearly.amount',
+            'utilizations.items[].org.name',
+            'utilizations.items[].country.name',
+        ];
+
         foreach (['default', null] as $group_name) {
             $result  = $this->instance::getFieldsSpecification($group_name);
             $sources = $this->instance::getSourcesSpecification($group_name);
@@ -88,11 +100,14 @@ class SpecificationsTest extends AbstractTestCase
 
                 $this->assertInternalType('array', $fillable_by);
 
-                // @todo: uncomment below after review
-                // $this->assertNotEmpty($fillable_by, "Path {$path} has empty 'fillable_by' attribute");
+                if (\in_array($path, $fillable_by_should_be_empty_for, true)) {
+                    $this->assertEmpty($fillable_by, "Path {$path} should have empty 'fillable_by' attribute");
+                } else {
+                    $this->assertNotEmpty($fillable_by, "Path {$path} has empty 'fillable_by' attribute");
+                }
 
                 foreach ($fillable_by as $source) {
-                    $this->assertTrue($sources->contains('name', $source));
+                    $this->assertTrue($sources->contains('name', $source), "Path [{$path}] contains invalid source [{$source}]");
                 }
 
                 $this->assertNotContains($path, $patches, "Fields specification contains field duplicate: {$path}");

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -4,7 +4,6 @@ namespace Avtocod\Specifications\Tests;
 
 use Exception;
 use Illuminate\Support\Collection;
-use PHPUnit\Framework\Constraint\IsType;
 use Avtocod\Specifications\Specifications;
 use Avtocod\Specifications\Structures\Field;
 use Avtocod\Specifications\Structures\Source;

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -74,6 +74,7 @@ class SpecificationsTest extends AbstractTestCase
             );
 
             $this->assertCount(\count($raw), $result);
+            $patches = [];
 
             foreach ($raw as $i => $field_data) {
                 $this->assertEquals($path = $field_data['path'], $result[$i]->getPath());
@@ -93,6 +94,9 @@ class SpecificationsTest extends AbstractTestCase
                 foreach ($fillable_by as $source) {
                     $this->assertTrue($sources->contains('name', $source));
                 }
+
+                $this->assertNotContains($path, $patches, "Fields specification contains field duplicate: {$path}");
+                $patches[] = $path;
             }
         }
     }
@@ -170,12 +174,15 @@ class SpecificationsTest extends AbstractTestCase
             );
 
             $this->assertCount(\count($raw), $result);
+            $types = [];
 
             foreach ($raw as $identifier_data) {
-                $identifier_type = $identifier_data['type'];
+                $type = $identifier_data['type'];
 
-                $this->assertEquals($identifier_data['description'], $result[$identifier_type]->getDescription());
-                $this->assertEquals($identifier_data['type'], $result[$identifier_type]->getType());
+                $this->assertEquals($identifier_data['description'], $result[$type]->getDescription());
+                $this->assertEquals($identifier_data['type'], $result[$type]->getType());
+                $this->assertNotContains($type, $types, "Identifier type contains duplicate: {$type}");
+                $types[] = $type;
             }
         }
     }
@@ -216,12 +223,15 @@ class SpecificationsTest extends AbstractTestCase
             );
 
             $this->assertCount(\count($raw), $result);
+            $names = [];
 
             foreach ($raw as $source_data) {
-                $source_name = $source_data['name'];
+                $name = $source_data['name'];
 
-                $this->assertEquals($source_data['name'], $result[$source_name]->getName());
-                $this->assertEquals($source_data['description'], $result[$source_name]->getDescription());
+                $this->assertEquals($source_data['name'], $result[$name]->getName());
+                $this->assertEquals($source_data['description'], $result[$name]->getDescription());
+                $this->assertNotContains($name, $names, "Sources names contains duplicate: {$name}");
+                $names[] = $name;
             }
         }
     }
@@ -249,12 +259,15 @@ class SpecificationsTest extends AbstractTestCase
             );
 
             $this->assertCount(count($raw), $result);
+            $mark_ids = [];
 
             foreach ($raw as $source_data) {
                 $mark_id = $source_data['id'];
 
                 $this->assertEquals($source_data['id'], $result[$mark_id]->getId());
                 $this->assertEquals($source_data['name'], $result[$mark_id]->getName());
+                $this->assertNotContains($mark_id, $mark_ids, "Mark ID contains duplicate: {$mark_id}");
+                $mark_ids[] = $mark_id;
             }
         }
     }
@@ -282,13 +295,16 @@ class SpecificationsTest extends AbstractTestCase
             );
 
             $this->assertCount(count($raw), $result);
+            $model_ids = [];
 
             foreach ($raw as $source_data) {
-                $mark_id = $source_data['id'];
+                $model_id = $source_data['id'];
 
-                $this->assertEquals($source_data['id'], $result[$mark_id]->getId());
-                $this->assertEquals($source_data['name'], $result[$mark_id]->getName());
-                $this->assertEquals($source_data['mark_id'], $result[$mark_id]->getMarkId());
+                $this->assertEquals($source_data['id'], $result[$model_id]->getId());
+                $this->assertEquals($source_data['name'], $result[$model_id]->getName());
+                $this->assertEquals($source_data['mark_id'], $result[$model_id]->getMarkId());
+                $this->assertNotContains($model_id, $model_ids, "Model ID contains duplicate: {$model_id}");
+                $model_ids[] = $model_id;
             }
         }
     }

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -58,7 +58,7 @@ class SpecificationsTest extends AbstractTestCase
     public function testGetFieldsSpecification()
     {
         foreach (['default', null] as $group_name) {
-            $result = $this->instance::getFieldsSpecification($group_name);
+            $result  = $this->instance::getFieldsSpecification($group_name);
             $sources = $this->instance::getSourcesSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -62,7 +62,8 @@ class SpecificationsTest extends AbstractTestCase
         $instance = $this->instance; // PHP 5.6
 
         foreach (['default', null] as $group_name) {
-            $result = $instance::getFieldsSpecification($group_name);
+            $result  = $instance::getFieldsSpecification($group_name);
+            $sources = $instance::getSourcesSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 
             foreach ($result as $item) {
@@ -82,6 +83,13 @@ class SpecificationsTest extends AbstractTestCase
                 $this->assertEquals($field_data['path'], $result[$field_name]->getPath());
                 $this->assertEquals($field_data['description'], $result[$field_name]->getDescription());
                 $this->assertEquals($field_data['types'], $result[$field_name]->getTypes());
+                // If field has 'fillable_by' sources, we must check that sources are in our spec
+                if (isset($field_data['fillable_by'])) {
+                    $this->assertEquals($field_data['fillable_by'], $result[$field_name]->getFillableBy());
+                    foreach ($field_data['fillable_by'] as $source) {
+                        $this->assertTrue($sources->contains('name', $source));
+                    }
+                }
             }
         }
     }

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -106,8 +106,12 @@ class SpecificationsTest extends AbstractTestCase
                     $this->assertNotEmpty($fillable_by, "Path {$path} has empty 'fillable_by' attribute");
                 }
 
+                $fillable_sources = [];
+
                 foreach ($fillable_by as $source) {
                     $this->assertTrue($sources->contains('name', $source), "Path [{$path}] contains invalid source [{$source}]");
+                    $this->assertNotContains($source, $fillable_sources, "Path [{$path}] contains source duplicate: {$source}");
+                    $fillable_sources[] = $source;
                 }
 
                 $this->assertNotContains($path, $patches, "Fields specification contains field duplicate: {$path}");

--- a/sdk/php/tests/Structures/FieldTest.php
+++ b/sdk/php/tests/Structures/FieldTest.php
@@ -20,11 +20,13 @@ class FieldTest extends AbstractStructureTestCase
             'path'        => $path = 'some path',
             'description' => $description = 'some description',
             'types'       => $types = ['some', 'types'],
+            'fillable_by' => $fillable_by = ['some.source', 'another.source'],
         ]);
 
         $this->assertEquals($path, $this->instance->getPath());
         $this->assertEquals($description, $this->instance->getDescription());
         $this->assertEquals($types, $this->instance->getTypes());
+        $this->assertEquals($fillable_by, $this->instance->getFillableBy());
 
         $this->assertEquals($input, $this->instance->toArray());
     }
@@ -38,11 +40,13 @@ class FieldTest extends AbstractStructureTestCase
             'path'        => null,
             'description' => null,
             'types'       => null,
+            'fillable_by' => null,
         ]);
 
         $this->assertNull($this->instance->getPath());
         $this->assertNull($this->instance->getDescription());
         $this->assertNull($this->instance->getTypes());
+        $this->assertNull($this->instance->getFillableBy());
     }
 
     /**

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -98,9 +98,5 @@
     {
         "name": "av.taxi",
         "description": null
-    },
-    {
-        "name": "taxi.registry",
-        "description": null
     }
 ]

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -82,5 +82,25 @@
     {
         "name": "repairs.history",
         "description": null
+    },
+    {
+        "name": "references.base",
+        "description": null
+    },
+    {
+        "name": "tech.base",
+        "description": null
+    },
+    {
+        "name": "pledge.house",
+        "description": null
+    },
+    {
+        "name": "av.taxi",
+        "description": null
+    },
+    {
+        "name": "taxi.registry",
+        "description": null
     }
 ]


### PR DESCRIPTION
Вопрос                | Ответ
--------------------- | ---
Это исправление?      | Нет
Это новый функционал? | Да 

## Описание

- Add `fillable_by` field for fields specification. This version includes sources that we could find out with responces stubs. **May be incompleted**.
- Add 'references.base' source into specification
- Add 'tech.base' source into specification
- Add 'pledge.house' source into specification
- Add 'av.taxi' source into specification
- Add 'taxi.registry' source into specificatio

Исправление #34

## Чек-лист

- [x] Мой код соответствует общему стилю этого проекта
- [x] Я самостоятельно просмотрел свой код
- [x] Я написал тесты на весь код, что был мною написан
- [x] Я оставил комментарии в своём коде там, где это необходимо
- [x] Я внёс соответствующие изменения в файл [CHANGELOG.md]
(https://github.com/avtocod/specs/blob/master/CHANGELOG.md)
