### PR TITLE
Travis config added

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,18 @@
+root = true
+
 [*]
-charset=utf-8
-end_of_line=lf
-insert_final_newline=false
-indent_style=space
-indent_size=4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,sh,conf}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,6 @@
 
 /sdk/php/tests       export-ignore
 /sdk/php/phpunit.xml export-ignore
-/tests               export-ignore
 /*.md                export-ignore
 /LICENSE*            export-ignore
 /.*                  export-ignore
-/phpunit.xml         export-ignore

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 80
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+- pinned
+- security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,8 @@
 filter:
   excluded_paths:
-    - tests/
+  - sdk/php/tests/
   dependency_paths:
-    - vendor/
+  - vendor/
 
 checks:
   php:
@@ -10,8 +10,7 @@ checks:
     duplication: true
 
 build_failure_conditions:
-  - 'elements.rating(<= D).exists'                                # No classes/methods with a rating of D or worse
-  - 'project.metric_change("scrutinizer.test_coverage", < -0.07)' # Coverage decreased from prev. inspection > 7%
+- 'elements.rating(<= D).exists'
 
 build:
   environment:
@@ -24,64 +23,12 @@ build:
     neo4j: false
     rabbitmq: false
 
-  tests:
-    override:
-      -
-        command: 'composer test-cover'
-        coverage:
-          file: './sdk/php/coverage/clover.xml'
-          format: 'clover'
-
   dependencies:
     override:
-      - composer update --no-interaction
+    - composer update --no-interaction
 
   nodes:
-    php56-lowest:
-      environment:
-        php: 5.6
-      dependencies:
-        override:
-          - composer update --no-interaction --prefer-lowest
-
-    php56:
-      environment:
-        php: 5.6
-
-    php70-lowest:
-      environment:
-        php: 7.0
-      dependencies:
-        override:
-          - composer update --no-interaction --prefer-lowest
-
-    php70:
-      environment:
-        php: 7.0
-
-    php71-lowest:
-      environment:
-        php: 7.1
-      dependencies:
-        override:
-          - composer update --no-interaction --prefer-lowest
-
-    php71:
-      environment:
-        php: 7.1
-
-    php72-lowest:
-      environment:
-        php: 7.2
-      dependencies:
-        override:
-          - composer update --no-interaction --prefer-lowest
-
-    php72:
-      environment:
-        php: 7.2
-
     analysis:
       tests:
         override:
-          - php-scrutinizer-run --enable-security-analysis
+        - php-scrutinizer-run --enable-security-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
 - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-stable --prefer-lowest; fi
 
 script:
-- composer phpstan
 - if [[ $coverage = 'true' ]]; then composer test-cover; else composer test; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-stable --prefer-lowest; fi
 
 script:
+- composer phpstan
 - if [[ $coverage = 'true' ]]; then composer test-cover; else composer test; fi
 
 after_success:
@@ -32,11 +33,6 @@ after_success:
 
 matrix:
   include:
-  - php: 5.6
-    env: setup=lowest
-  - php: 5.6
-    env: setup=stable
-
   - php: 7.0
     env: coverage=true
   - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,70 @@
+language: php
+
+cache:
+  directories:
+  - $HOME/.composer/cache
+
+env:
+  global:
+  - setup=basic
+  - coverage=false
+
+sudo: false
+
+branches:
+  except:
+  - gh-pages
+  - /analysis-.*/
+
+before_install:
+- if [[ $coverage = 'false' ]]; then phpenv config-rm xdebug.ini || true; fi
+
+install:
+- if [[ $setup = 'basic'  ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest; fi
+- if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-stable; fi
+- if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-stable --prefer-lowest; fi
+
+script:
+- composer phpstan
+- if [[ $coverage = 'true' ]]; then composer test-cover; else composer test; fi
+
+after_success:
+- if [[ $coverage = 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi
+
+matrix:
+  include:
+  - php: 5.6
+    env: setup=lowest
+  - php: 5.6
+    env: setup=stable
+
+  - php: 7.0
+    env: coverage=true
+  - php: 7.0
+    env: setup=lowest
+  - php: 7.0
+    env: setup=stable
+
+  - php: 7.1
+    env: coverage=true
+  - php: 7.1
+    env: setup=lowest
+  - php: 7.1
+    env: setup=stable
+
+  - php: 7.2
+    env: coverage=true
+  - php: 7.2
+    env: setup=lowest
+  - php: 7.2
+    env: setup=stable
+
+  - php: 7.3
+    env: setup=lowest
+  - php: 7.3
+    env: setup=stable
+
+  - php: nightly
+
+  allow_failures:
+  - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,10 @@ after_success:
 matrix:
   include:
   - php: 7.0
-    env: coverage=true
-  - php: 7.0
     env: setup=lowest
   - php: 7.0
     env: setup=stable
 
-  - php: 7.1
-    env: coverage=true
   - php: 7.1
     env: setup=lowest
   - php: 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
+
+## v2.11.0
+
+### Changed
+
+- Migrate to the [Travis CI][travis-ci]
+- **PHP SDK** minimal PHP version now is 7.0 _([version 5.6 is not supported since 31 Dec 2018][php-supported-versions])_
+- **PHP SDK** code a little bit refactored for PHP version 7.0
+
+### Added
+
+- **PHP SDK** Static code analyzer `phpstan` installed as `dev` dependency
+
+[php-supported-versions]:http://php.net/supported-versions.php
+[travis-ci]:https://travis-ci.org/avtocod/specs
+
 ## v2.10.0
 
 ### Added
@@ -154,5 +173,7 @@
 - Report example `./fields/default/examples/Z94CB41AAGR323020.json`
 - Report example `./fields/default/examples/A1111111111111111.json`
 
+[keepachangelog]:https://keepachangelog.com/en/1.0.0/
+[semver]:https://semver.org/spec/v2.0.0.html
 [#12]:https://github.com/avtocod/specs/issues/12
 [#9]:https://github.com/avtocod/specs/issues/9

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 #### PHP SDK
 
 [![Build Status][badge_build_status]][link_build_status]
+[![Coverage][badge_coverage]][link_coverage]
 [![Version][badge_packagist_version]][link_packagist]
 ![Required PHP version][badge_php_version]
 [![Downloads count][badge_packagist_dl_count]][link_packagist]
@@ -109,16 +110,18 @@ $fields_specifications = \Avtocod\Specifications\Specifications::getFieldsSpecif
 [badge_release_version]:https://img.shields.io/github/release/avtocod/specs.svg?style=for-the-badge&maxAge=5
 [badge_release_date]:https://img.shields.io/github/release-date/avtocod/specs.svg?style=for-the-badge&maxAge=5
 [badge_commits_since_release]:https://img.shields.io/github/commits-since/avtocod/specs/latest.svg?style=for-the-badge&maxAge=5
-[badge_packagist_version]:https://img.shields.io/packagist/v/avtocod/specs.svg?style=flat-square&maxAge=5
-[badge_php_version]:https://img.shields.io/packagist/php-v/avtocod/specs.svg?style=flat-square&maxAge=5
-[badge_build_status]:https://img.shields.io/scrutinizer/build/g/avtocod/specs.svg?style=flat-square&maxAge=120&logo=scrutinizer
-[badge_packagist_dl_count]:https://img.shields.io/packagist/dt/avtocod/specs.svg?style=flat-square&maxAge=30
+[badge_packagist_version]:https://img.shields.io/packagist/v/avtocod/specs.svg?maxAge=5
+[badge_php_version]:https://img.shields.io/packagist/php-v/avtocod/specs.svg?maxAge=5
+[badge_build_status]:https://travis-ci.org/avtocod/specs.svg?branch=master
+[badge_packagist_dl_count]:https://img.shields.io/packagist/dt/avtocod/specs.svg?maxAge=30
 [badge_issues]:https://img.shields.io/github/issues/avtocod/specs.svg?style=for-the-badge&maxAge=30
 [badge_releases_dl_count]:https://img.shields.io/github/downloads/avtocod/specs/total.svg?style=for-the-badge&maxAge=30
+[badge_coverage]:https://img.shields.io/codecov/c/github/avtocod/specs/master.svg?maxAge=5
 [link_packagist]:https://packagist.org/packages/avtocod/specs
-[link_build_status]:https://scrutinizer-ci.com/g/avtocod/specs/build-status/master
+[link_build_status]:https://travis-ci.org/avtocod/specs
 [link_issues]:https://github.com/avtocod/specs/issues
 [link_create_issue]:https://github.com/avtocod/specs/issues/new/choose
+[link_coverage]:https://codecov.io/gh/avtocod/specs
 [getcomposer]:https://getcomposer.org/download/
 [git_tagging]:https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [watch_repo]:https://github.com/avtocod/specs/subscription

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.0",
         "ext-json": "*",
         "illuminate/support": ">=5.4 <5.8.0",
-        "tarampampam/wrappers-php": "^1.2"
+        "tarampampam/wrappers-php": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.10 || ^6.4 || ~7.0",

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,15 @@
         }
     ],
     "require": {
-        "php": "^5.6.4 || >=7.0 <=7.3",
+        "php": ">=7.0",
         "ext-json": "*",
-        "illuminate/support": ">=5.4 <5.7.0"
+        "illuminate/support": ">=5.4 <5.8.0",
+        "tarampampam/wrappers-php": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.10 || ^6.4 || ~7.0",
-        "symfony/var-dumper": "~3.2 || ^4.0"
+        "symfony/var-dumper": "~3.2 || ^4.0",
+        "phpstan/phpstan": "~0.9 || ^0.10"
     },
     "autoload": {
         "psr-4": {
@@ -35,7 +37,8 @@
     },
     "scripts": {
         "test": "@php ./vendor/bin/phpunit --no-coverage --configuration ./sdk/php/phpunit.xml",
-        "test-cover": "@php ./vendor/bin/phpunit --configuration ./sdk/php/phpunit.xml"
+        "test-cover": "@php ./vendor/bin/phpunit --configuration ./sdk/php/phpunit.xml",
+        "phpstan": "@php ./vendor/bin/phpstan analyze --no-progress --ansi --level=max ./sdk/php/src"
     },
     "support": {
         "issues": "https://github.com/avtocod/specs/issues",

--- a/sdk/php/src/Specifications.php
+++ b/sdk/php/src/Specifications.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications;
 

--- a/sdk/php/src/Specifications.php
+++ b/sdk/php/src/Specifications.php
@@ -1,14 +1,19 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications;
 
 use Exception;
+use InvalidArgumentException;
+use Tarampampam\Wrappers\Json;
 use Illuminate\Support\Collection;
 use Avtocod\Specifications\Structures\Field;
 use Avtocod\Specifications\Structures\Source;
 use Avtocod\Specifications\Structures\VehicleMark;
 use Avtocod\Specifications\Structures\VehicleModel;
 use Avtocod\Specifications\Structures\IdentifierType;
+use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 class Specifications
 {
@@ -24,12 +29,12 @@ class Specifications
      *
      * @return string
      */
-    public static function getRootDirectoryPath($additional_path = null)
+    public static function getRootDirectoryPath(string $additional_path = null): string
     {
-        $root = dirname(dirname(dirname(__DIR__))); // `dirname()` reason - https://git.io/vhXvr
+        $root = \dirname(\dirname(\dirname(__DIR__))); // `dirname()` reason - https://git.io/vhXvr
 
         return $additional_path !== null
-            ? $root . DIRECTORY_SEPARATOR . ltrim((string) $additional_path, ' \\/')
+            ? $root . DIRECTORY_SEPARATOR . ltrim($additional_path, ' \\/')
             : $root;
     }
 
@@ -42,11 +47,9 @@ class Specifications
      *
      * @return Collection|Field[]
      */
-    public static function getFieldsSpecification($group_name = null)
+    public static function getFieldsSpecification(string $group_name = null): Collection
     {
-        $group_name = $group_name === null
-            ? self::GROUP_NAME_DEFAULT
-            : $group_name;
+        $group_name = $group_name ?? self::GROUP_NAME_DEFAULT;
 
         $result = new Collection;
         $input  = static::getJsonFileAsArray(
@@ -68,11 +71,9 @@ class Specifications
      *
      * @return array
      */
-    public static function getReportExample($group_name = null, $name = 'full')
+    public static function getReportExample(string $group_name = null, string $name = 'full'): array
     {
-        $group_name = $group_name === null
-            ? self::GROUP_NAME_DEFAULT
-            : $group_name;
+        $group_name = $group_name ?? self::GROUP_NAME_DEFAULT;
 
         return static::getJsonFileAsArray(
             static::getRootDirectoryPath("/fields/{$group_name}/examples/{$name}.json")
@@ -88,11 +89,9 @@ class Specifications
      *
      * @return Collection|IdentifierType[]
      */
-    public static function getIdentifierTypesSpecification($group_name = null)
+    public static function getIdentifierTypesSpecification(string $group_name = null): Collection
     {
-        $group_name = $group_name === null
-            ? self::GROUP_NAME_DEFAULT
-            : $group_name;
+        $group_name = $group_name ?? self::GROUP_NAME_DEFAULT;
 
         $result = new Collection;
         $input  = static::getJsonFileAsArray(
@@ -115,11 +114,9 @@ class Specifications
      *
      * @return Collection|Source[]
      */
-    public static function getSourcesSpecification($group_name = null)
+    public static function getSourcesSpecification(string $group_name = null): Collection
     {
-        $group_name = $group_name === null
-            ? self::GROUP_NAME_DEFAULT
-            : $group_name;
+        $group_name = $group_name ?? self::GROUP_NAME_DEFAULT;
 
         $result = new Collection;
         $input  = static::getJsonFileAsArray(
@@ -142,11 +139,9 @@ class Specifications
      *
      * @return Collection|VehicleMark[]
      */
-    public static function getVehicleMarksSpecification($group_name = null)
+    public static function getVehicleMarksSpecification(string $group_name = null): Collection
     {
-        $group_name = $group_name === null
-            ? self::GROUP_NAME_DEFAULT
-            : $group_name;
+        $group_name = $group_name ?? self::GROUP_NAME_DEFAULT;
 
         $result = new Collection;
         $input  = static::getJsonFileAsArray(
@@ -169,11 +164,9 @@ class Specifications
      *
      * @return Collection|VehicleModel[]
      */
-    public static function getVehicleModelsSpecification($group_name = null)
+    public static function getVehicleModelsSpecification(string $group_name = null): Collection
     {
-        $group_name = $group_name === null
-            ? self::GROUP_NAME_DEFAULT
-            : $group_name;
+        $group_name = $group_name ?? self::GROUP_NAME_DEFAULT;
 
         $result = new Collection;
         $input  = static::getJsonFileAsArray(
@@ -192,24 +185,17 @@ class Specifications
      *
      * @param string $file_path
      *
-     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws JsonEncodeDecodeException
      *
      * @return array
      */
-    protected static function getJsonFileAsArray($file_path)
+    protected static function getJsonFileAsArray(string $file_path): array
     {
-        if (! \file_exists($file_path)) {
-            throw new Exception("File [{$file_path}] was not found");
+        if (! \is_file($file_path)) {
+            throw new \InvalidArgumentException("File [{$file_path}] was not found");
         }
 
-        $result = \json_decode(file_get_contents($file_path), true);
-
-        if (! \is_array($result) || \json_last_error() !== JSON_ERROR_NONE) {
-            // @codeCoverageIgnoreStart
-            throw new Exception("Cannot parse json file: [{$file_path}]");
-            // @codeCoverageIgnoreEnd
-        }
-
-        return $result;
+        return (array) Json::decode((string) \file_get_contents($file_path), true);
     }
 }

--- a/sdk/php/src/Structures/AbstractStructure.php
+++ b/sdk/php/src/Structures/AbstractStructure.php
@@ -1,13 +1,17 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Structures;
 
 use ArrayAccess;
 use ArrayIterator;
 use LogicException;
 use IteratorAggregate;
+use Tarampampam\Wrappers\Json;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 abstract class AbstractStructure implements Arrayable, Jsonable, ArrayAccess, IteratorAggregate
 {
@@ -23,18 +27,20 @@ abstract class AbstractStructure implements Arrayable, Jsonable, ArrayAccess, It
 
     /**
      * {@inheritdoc}
+     *
+     * @throws JsonEncodeDecodeException
      */
-    public function toJson($options = 0)
+    public function toJson($options = 0): string
     {
-        return \json_encode($this->toArray(), $options);
+        return Json::encode($this->toArray(), $options);
     }
 
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator
+     * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->toArray());
     }
@@ -42,9 +48,9 @@ abstract class AbstractStructure implements Arrayable, Jsonable, ArrayAccess, It
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
-        return (bool) \property_exists($this, $offset);
+        return \property_exists($this, $offset);
     }
 
     /**

--- a/sdk/php/src/Structures/AbstractStructure.php
+++ b/sdk/php/src/Structures/AbstractStructure.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 

--- a/sdk/php/src/Structures/Field.php
+++ b/sdk/php/src/Structures/Field.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Structures;
 
 use Traversable;
@@ -33,14 +35,14 @@ class Field extends AbstractStructure
     /**
      * Possible data types.
      *
-     * @var string[]|array
+     * @var string[]|null
      */
-    protected $types = [];
+    protected $types;
 
     /**
      * {@inheritdoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'path'        => $this->path,
@@ -74,15 +76,15 @@ class Field extends AbstractStructure
      *
      * @return string[]|array
      */
-    public function getPathParts()
+    public function getPathParts(): array
     {
-        return \array_values(\array_filter(\explode(static::PATH_DELIMITER, $this->path)));
+        return \array_values(\array_filter(\explode(static::PATH_DELIMITER, (string) $this->path)));
     }
 
     /**
      * Get possible data types.
      *
-     * @return array|string[]
+     * @return string[]|null
      */
     public function getTypes()
     {
@@ -94,9 +96,9 @@ class Field extends AbstractStructure
      *
      * @return int
      */
-    public function nestingDepth()
+    public function nestingDepth(): int
     {
-        return \mb_substr_count($this->path, static::NESTING_SIGNATURE);
+        return \mb_substr_count((string) $this->path, static::NESTING_SIGNATURE);
     }
 
     /**
@@ -104,7 +106,7 @@ class Field extends AbstractStructure
      *
      * @return bool
      */
-    public function isNested()
+    public function isNested(): bool
     {
         return $this->nestingDepth() > 0;
     }
@@ -130,9 +132,12 @@ class Field extends AbstractStructure
                         break;
 
                     case 'types':
-                        $this->types = $value === null
+                        /** @var string[]|null $value */
+                        $value === null
                             ? null
-                            : (array) $value;
+                            : \array_filter((array) $value, '\is_string');
+
+                        $this->types = $value;
                         break;
                 }
             }

--- a/sdk/php/src/Structures/Field.php
+++ b/sdk/php/src/Structures/Field.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
@@ -132,7 +132,7 @@ class Field extends AbstractStructure
                         break;
 
                     case 'types':
-                        /** @var string[]|null $value */
+                        /* @var string[]|null $value */
                         $value === null
                             ? null
                             : \array_filter((array) $value, '\is_string');

--- a/sdk/php/src/Structures/IdentifierType.php
+++ b/sdk/php/src/Structures/IdentifierType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Structures;
 
 use Traversable;
@@ -23,7 +25,7 @@ class IdentifierType extends AbstractStructure
     /**
      * {@inheritdoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'type'        => $this->type,

--- a/sdk/php/src/Structures/IdentifierType.php
+++ b/sdk/php/src/Structures/IdentifierType.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 

--- a/sdk/php/src/Structures/Source.php
+++ b/sdk/php/src/Structures/Source.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Structures;
 
 use Traversable;
@@ -23,7 +25,7 @@ class Source extends AbstractStructure
     /**
      * {@inheritdoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'name'        => $this->name,

--- a/sdk/php/src/Structures/Source.php
+++ b/sdk/php/src/Structures/Source.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 

--- a/sdk/php/src/Structures/VehicleMark.php
+++ b/sdk/php/src/Structures/VehicleMark.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Structures;
 
 use Traversable;
@@ -23,7 +25,7 @@ class VehicleMark extends AbstractStructure
     /**
      * {@inheritdoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'name' => $this->name,

--- a/sdk/php/src/Structures/VehicleMark.php
+++ b/sdk/php/src/Structures/VehicleMark.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 

--- a/sdk/php/src/Structures/VehicleModel.php
+++ b/sdk/php/src/Structures/VehicleModel.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 

--- a/sdk/php/src/Structures/VehicleModel.php
+++ b/sdk/php/src/Structures/VehicleModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Structures;
 
 use Traversable;
@@ -30,7 +32,7 @@ class VehicleModel extends AbstractStructure
     /**
      * {@inheritdoc}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'name'    => $this->name,

--- a/sdk/php/tests/AbstractTestCase.php
+++ b/sdk/php/tests/AbstractTestCase.php
@@ -13,6 +13,6 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function getRootDirPath()
     {
-        return realpath(__DIR__ . '/../../..');
+        return \realpath(__DIR__ . '/../../..');
     }
 }

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -45,11 +45,9 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetRootDirectoryPath()
     {
-        $instance = $this->instance; // PHP 5.6
-
-        $this->assertEquals($instance::getRootDirectoryPath(), $root = $this->getRootDirPath());
-        $this->assertEquals($instance::getRootDirectoryPath('foo'), $root . DIRECTORY_SEPARATOR . 'foo');
-        $this->assertEquals($instance::getRootDirectoryPath(' /foo'), $root . DIRECTORY_SEPARATOR . 'foo');
+        $this->assertEquals($this->instance::getRootDirectoryPath(), $root = $this->getRootDirPath());
+        $this->assertEquals($this->instance::getRootDirectoryPath('foo'), $root . DIRECTORY_SEPARATOR . 'foo');
+        $this->assertEquals($this->instance::getRootDirectoryPath(' /foo'), $root . DIRECTORY_SEPARATOR . 'foo');
     }
 
     /**
@@ -59,10 +57,8 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetFieldsSpecification()
     {
-        $instance = $this->instance; // PHP 5.6
-
         foreach (['default', null] as $group_name) {
-            $result = $instance::getFieldsSpecification($group_name);
+            $result = $this->instance::getFieldsSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 
             foreach ($result as $item) {
@@ -70,13 +66,13 @@ class SpecificationsTest extends AbstractTestCase
             }
 
             $raw = \json_decode(
-                \file_get_contents($instance::getRootDirectoryPath(
+                \file_get_contents($this->instance::getRootDirectoryPath(
                     '/fields/default/fields_list.json'
                 )),
                 true
             );
 
-            $this->assertCount(count($raw), $result);
+            $this->assertCount(\count($raw), $result);
 
             foreach ($raw as $field_name => $field_data) {
                 $this->assertEquals($field_data['path'], $result[$field_name]->getPath());
@@ -96,9 +92,7 @@ class SpecificationsTest extends AbstractTestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
 
-        $instance = $this->instance; // PHP 5.6
-
-        $instance::getFieldsSpecification('foo bar');
+        $this->instance::getFieldsSpecification('foo bar');
     }
 
     /**
@@ -108,15 +102,13 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetReportExample()
     {
-        $instance = $this->instance; // PHP 5.6
-
         foreach (['default', null] as $group_name) {
             foreach (['full', 'empty'] as $name) {
-                $result = $instance::getReportExample($group_name, $name);
+                $result = $this->instance::getReportExample($group_name, $name);
                 $this->assertInternalType('array', $result);
 
                 $raw = \json_decode(
-                    \file_get_contents($instance::getRootDirectoryPath(
+                    \file_get_contents($this->instance::getRootDirectoryPath(
                         "/fields/default/examples/{$name}.json"
                     )),
                     true
@@ -137,9 +129,7 @@ class SpecificationsTest extends AbstractTestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
 
-        $instance = $this->instance; // PHP 5.6
-
-        $instance::getReportExample('foo bar');
+        $this->instance::getReportExample('foo bar');
     }
 
     /**
@@ -149,10 +139,8 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetIdentifierTypesSpecification()
     {
-        $instance = $this->instance; // PHP 5.6
-
         foreach (['default', null] as $group_name) {
-            $result = $instance::getIdentifierTypesSpecification($group_name);
+            $result = $this->instance::getIdentifierTypesSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 
             foreach ($result as $item) {
@@ -160,13 +148,13 @@ class SpecificationsTest extends AbstractTestCase
             }
 
             $raw = \json_decode(
-                \file_get_contents($instance::getRootDirectoryPath(
+                \file_get_contents($this->instance::getRootDirectoryPath(
                     '/identifiers/default/types_list.json'
                 )),
                 true
             );
 
-            $this->assertCount(count($raw), $result);
+            $this->assertCount(\count($raw), $result);
 
             foreach ($raw as $identifier_data) {
                 $identifier_type = $identifier_data['type'];
@@ -187,9 +175,7 @@ class SpecificationsTest extends AbstractTestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
 
-        $instance = $this->instance; // PHP 5.6
-
-        $instance::getIdentifierTypesSpecification('foo bar');
+        $this->instance::getIdentifierTypesSpecification('foo bar');
     }
 
     /**
@@ -199,10 +185,8 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetSourcesSpecification()
     {
-        $instance = $this->instance; // PHP 5.6
-
         foreach (['default', null] as $group_name) {
-            $result = $instance::getSourcesSpecification($group_name);
+            $result = $this->instance::getSourcesSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 
             foreach ($result as $item) {
@@ -210,13 +194,13 @@ class SpecificationsTest extends AbstractTestCase
             }
 
             $raw = \json_decode(
-                \file_get_contents($instance::getRootDirectoryPath(
+                \file_get_contents($this->instance::getRootDirectoryPath(
                     '/sources/default/sources_list.json'
                 )),
                 true
             );
 
-            $this->assertCount(count($raw), $result);
+            $this->assertCount(\count($raw), $result);
 
             foreach ($raw as $source_data) {
                 $source_name = $source_data['name'];
@@ -234,10 +218,8 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetVehiclesMarksSpecification()
     {
-        $instance = $this->instance; // PHP 5.6
-
         foreach (['default', null] as $group_name) {
-            $result = $instance::getVehicleMarksSpecification($group_name);
+            $result = $this->instance::getVehicleMarksSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 
             foreach ($result as $item) {
@@ -245,7 +227,7 @@ class SpecificationsTest extends AbstractTestCase
             }
 
             $raw = \json_decode(
-                \file_get_contents($instance::getRootDirectoryPath(
+                \file_get_contents($this->instance::getRootDirectoryPath(
                     '/vehicles/default/marks.json'
                 )),
                 true
@@ -269,10 +251,8 @@ class SpecificationsTest extends AbstractTestCase
      */
     public function testGetVehicleModelsSpecification()
     {
-        $instance = $this->instance; // PHP 5.6
-
         foreach (['default', null] as $group_name) {
-            $result = $instance::getVehicleModelsSpecification($group_name);
+            $result = $this->instance::getVehicleModelsSpecification($group_name);
             $this->assertInstanceOf(Collection::class, $result);
 
             foreach ($result as $item) {
@@ -280,7 +260,7 @@ class SpecificationsTest extends AbstractTestCase
             }
 
             $raw = \json_decode(
-                \file_get_contents($instance::getRootDirectoryPath(
+                \file_get_contents($this->instance::getRootDirectoryPath(
                     '/vehicles/default/models.json'
                 )),
                 true
@@ -308,8 +288,6 @@ class SpecificationsTest extends AbstractTestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
 
-        $instance = $this->instance; // PHP 5.6
-
-        $instance::getSourcesSpecification('foo bar');
+        $this->instance::getSourcesSpecification('foo bar');
     }
 }


### PR DESCRIPTION
### Changed

- Migrate to the [Travis CI][travis-ci]
- **PHP SDK** minimal PHP version now is 7.0 _([version 5.6 is not supported since 31 Dec 2018][php-supported-versions])_
- **PHP SDK** code a little bit refactored for PHP version 7.0

### Added

- **PHP SDK** Static code analyzer `phpstan` installed as `dev` dependency

[php-supported-versions]:http://php.net/supported-versions.php
[travis-ci]:https://travis-ci.org/avtocod/specs