### PR TITLE
Up PHP and illuminate/* versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-[*.md]
+[*.{md,json}]
 trim_trailing_whitespace = false
 
 [*.{yml,yaml,sh,conf}]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# @link <https://help.github.com/en/articles/about-code-owners>
+
+* @tarampampam @Reallife

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,33 @@
-Вопрос                | Ответ
---------------------- | ---
-Это исправление?      | Да / Нет
-Это новый функционал? | Да / Нет
+| Q             | A
+| ------------- | ---
+| Bug fix?      | Yes or No
+| New feature?  | Yes or No
 
-## Описание
+## Description
 
-> В произвольной форме опишите что именно изменяют или исправляют предложенные вами изменения. Если возможно - сгруппируйте их в блоки "Изменено", "Добавлено" и "Удалено".
+<!--
 
-Исправление # (issue)
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-## Чек-лист
+-->
 
-- [ ] Мой код соответствует общему стилю этого проекта
-- [ ] Я самостоятельно просмотрел свой код
-- [ ] Я оставил комментарии в своём коде там, где это необходимо
-- [ ] Я написал тесты на весь код, что был мною написан
-- [ ] Я внёс соответствующие изменения в файл [CHANGELOG.md](https://github.com/avtocod/specs/blob/master/CHANGELOG.md)
+Fixes # (issue)
 
-> Об изменениях файла `CHANGELOG.md`:
->
-> * Добавь заголовок новой версии вида `## v3.x.x`, если его не существует
-> * Добавь описания в секции `Added` / `Changed` / `Fixed`
-> * Добавь ссылку на соответствующие issues `[#000]`
-> * Добавь ссылки на issues в конец документа
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I wrote unit tests for my code
+- [ ] I have made changes in [CHANGELOG.md](https://github.com/avtocod/specs/blob/master/CHANGELOG.md) file
+
+<!--
+
+About your changes in `CHANGELOG.md`:
+
+* Add new version header like `## v1.x.x`, if it does not exists
+* Add description under `added`/`changed`/`fixed` sections
+* Add reference to closed issues `[#000]`
+* Add link to issue in the end of document
+
+-->

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,60 +2,55 @@ language: php
 
 cache:
   directories:
-  - $HOME/.composer/cache
+    - $HOME/.composer/cache
 
 env:
   global:
-  - setup=basic
-  - coverage=false
+    - setup=basic
+    - coverage=false
 
 sudo: false
 
 branches:
   except:
-  - gh-pages
-  - /analysis-.*/
+    - gh-pages
+    - /analysis-.*/
 
 before_install:
-- if [[ $coverage = 'false' ]]; then phpenv config-rm xdebug.ini || true; fi
+  - if [[ $coverage = 'false' ]]; then phpenv config-rm xdebug.ini || true; fi
+  - composer global require hirak/prestissimo --update-no-dev
 
 install:
-- if [[ $setup = 'basic'  ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest; fi
-- if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-stable; fi
-- if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-lowest; fi
+  - if [[ $setup = 'basic'  ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest; fi
+  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-stable; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --no-suggest --prefer-lowest; fi
 
 script:
-- composer phpstan
-- if [[ $coverage = 'true' ]]; then composer test-cover; else composer test; fi
+  - if [[ $coverage = 'true' ]]; then composer test-cover; else composer test; fi
 
 after_success:
-- if [[ $coverage = 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ $coverage = 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 matrix:
   include:
-  - php: 7.0
-    env: setup=lowest
-  - php: 7.0
-    env: setup=stable
+    - php: 7.1.3
+      env: setup=lowest
+    - php: 7.1.3
+      env: setup=stable
 
-  - php: 7.1
-    env: setup=lowest
-  - php: 7.1
-    env: setup=stable
+    - php: 7.2
+      env: coverage=true
+    - php: 7.2
+      env: setup=lowest
+    - php: 7.2
+      env: setup=stable
 
-  - php: 7.2
-    env: coverage=true
-  - php: 7.2
-    env: setup=lowest
-  - php: 7.2
-    env: setup=stable
+    - php: 7.3
+      env: setup=lowest
+    - php: 7.3
+      env: setup=stable
 
-  - php: 7.3
-    env: setup=lowest
-  - php: 7.3
-    env: setup=stable
-
-  - php: nightly
+    - php: nightly
 
   allow_failures:
-  - php: nightly
+    - php: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.7.0
+
+### Changed
+
+- **PHP SDK** minimal `PHP` version now is `7.1.3`
+- **PHP SDK** maximal `illuminate/support` dependency version now is `5.8.x`
+
 ## v3.6.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1.3",
         "ext-json": "*",
-        "illuminate/support": ">=5.4 <5.8.0",
+        "illuminate/support": ">=5.4 <5.9.0",
         "ocramius/package-versions": "^1.0",
         "tarampampam/wrappers-php": "^1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.10 || ^6.4 || ~7.0",
+        "phpunit/phpunit": "~5.7.10 || ^6.4 || ~7.5",
         "symfony/var-dumper": "~3.2 || ^4.0",
-        "phpstan/phpstan": "~0.9 || ^0.10",
+        "phpstan/phpstan": "^0.11.3",
         "opis/json-schema": "^1.0"
     },
     "autoload": {
@@ -38,9 +38,18 @@
         }
     },
     "scripts": {
-        "test": "@php ./vendor/bin/phpunit --no-coverage --configuration ./sdk/php/phpunit.xml",
-        "test-cover": "@php ./vendor/bin/phpunit --configuration ./sdk/php/phpunit.xml",
-        "phpstan": "@php ./vendor/bin/phpstan analyze --no-progress --ansi --level=max ./sdk/php/src"
+        "phpunit": "@php ./vendor/bin/phpunit --configuration ./sdk/php/phpunit.xml.dist --no-coverage --colors=always",
+        "phpunit-feature": "@php ./vendor/bin/phpunit --configuration ./sdk/php/phpunit.xml.dist --no-coverage --colors=always",
+        "phpunit-cover": "@php ./vendor/bin/phpunit --configuration ./sdk/php/phpunit.xml.dist --coverage-html='./coverage/html'",
+        "phpstan": "@php ./vendor/bin/phpstan analyze --no-progress --ansi --level=max ./sdk/php/src",
+        "test": [
+            "@phpstan",
+            "@phpunit"
+        ],
+        "test-cover": [
+            "@phpstan",
+            "@phpunit-cover"
+        ]
     },
     "support": {
         "issues": "https://github.com/avtocod/specs/issues",

--- a/sdk/php/phpunit.xml.dist
+++ b/sdk/php/phpunit.xml.dist
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit bootstrap="tests/bootstrap.php"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
+         forceCoversAnnotation="true"
          stopOnFailure="true">
     <testsuites>
         <testsuite name="Unit">

--- a/sdk/php/src/Specifications.php
+++ b/sdk/php/src/Specifications.php
@@ -22,17 +22,17 @@ class Specifications
     /**
      * Self package name.
      */
-    const SELF_PACKAGE_NAME = 'avtocod/specs';
+    public const SELF_PACKAGE_NAME = 'avtocod/specs';
 
     /**
      * Default specification group name.
      */
-    const GROUP_NAME_DEFAULT = 'default';
+    public const GROUP_NAME_DEFAULT = 'default';
 
     /**
      * Default vehicle type.
      */
-    const VEHICLE_TYPE_DEFAULT = 'ID_TYPE_CAR';
+    public const VEHICLE_TYPE_DEFAULT = 'ID_TYPE_CAR';
 
     /**
      * Get current package version.

--- a/sdk/php/tests/AbstractTestCase.php
+++ b/sdk/php/tests/AbstractTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Tests;
 

--- a/sdk/php/tests/AbstractTestCase.php
+++ b/sdk/php/tests/AbstractTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Tests;
 
 use PHPUnit\Framework\TestCase;
@@ -9,10 +11,10 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Get the root directory path.
      *
-     * @return bool|string
+     * @return string
      */
-    protected function getRootDirPath()
+    protected function getRootDirPath(): string
     {
-        return \realpath(__DIR__ . '/../../..');
+        return (string) \realpath(__DIR__ . '/../../..');
     }
 }

--- a/sdk/php/tests/SpecificationsDatum/SpecFilesTest.php
+++ b/sdk/php/tests/SpecificationsDatum/SpecFilesTest.php
@@ -17,7 +17,7 @@ class SpecFilesTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testDirectoriesStructure()
+    public function testDirectoriesStructure(): void
     {
         $root = $this->getRootDirPath();
 
@@ -46,7 +46,7 @@ class SpecFilesTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testFilesStructure()
+    public function testFilesStructure(): void
     {
         $root = $this->getRootDirPath();
 
@@ -93,7 +93,7 @@ class SpecFilesTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testJsonFilesFormat()
+    public function testJsonFilesFormat(): void
     {
         $root = $this->getRootDirPath();
 
@@ -130,7 +130,7 @@ class SpecFilesTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testReportsExamples()
+    public function testReportsExamples(): void
     {
         $not_setted = sprintf('__NOT_SETTED_%s__', md5(microtime(true)));
 

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Tests;
 
 use Exception;
 use ReflectionClass;
+use ReflectionMethod;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Opis\JsonSchema\Schema;
@@ -38,7 +41,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -51,7 +54,7 @@ class SpecificationsTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testConstants()
+    public function testConstants(): void
     {
         $this->assertEquals('default', Specifications::GROUP_NAME_DEFAULT);
     }
@@ -59,7 +62,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetRootDirectoryPath()
+    public function testGetRootDirectoryPath(): void
     {
         $this->assertEquals($this->instance::getRootDirectoryPath(), $root = $this->getRootDirPath());
         $this->assertEquals($this->instance::getRootDirectoryPath('foo'), $root . DIRECTORY_SEPARATOR . 'foo');
@@ -69,7 +72,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetFieldsSpecification()
+    public function testGetFieldsSpecification(): void
     {
         $fillable_by_should_be_empty_for = [
             'tech_data.manufacturer.name',
@@ -138,7 +141,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetFieldsJsonSchema()
+    public function testGetFieldsJsonSchema(): void
     {
         foreach (['default', null] as $group_name) {
             $this->assertInternalType('object', $as_object = $this->instance::getFieldsJsonSchema($group_name));
@@ -154,7 +157,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testFieldsJsonSchemaValidation()
+    public function testFieldsJsonSchemaValidation(): void
     {
         $fields_raw = Json::decode(\file_get_contents(
             $this->instance::getRootDirectoryPath('/fields/default/fields_list.json')
@@ -168,7 +171,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetReportExample()
+    public function testGetReportExample(): void
     {
         foreach (['default', null] as $group_name) {
             foreach (['full', 'empty'] as $name) {
@@ -189,7 +192,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetReportExampleWithInvalidGroupName()
+    public function testGetReportExampleWithInvalidGroupName(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
@@ -200,7 +203,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetReportJsonSchema()
+    public function testGetReportJsonSchema(): void
     {
         foreach (['default', null] as $group_name) {
             $this->assertInternalType('object', $as_object = $this->instance::getReportJsonSchema($group_name));
@@ -216,7 +219,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testReportExamplesUsingSchemaValidator()
+    public function testReportExamplesUsingSchemaValidator(): void
     {
         foreach (['default', null] as $group_name) {
             foreach (['full', 'empty'] as $report_example_type) {
@@ -235,7 +238,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetIdentifierTypesSpecification()
+    public function testGetIdentifierTypesSpecification(): void
     {
         foreach (['default', null] as $group_name) {
             $result = $this->instance::getIdentifierTypesSpecification($group_name);
@@ -270,7 +273,7 @@ class SpecificationsTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testGetIdentifierTypesSpecificationWithInvalidGroupName()
+    public function testGetIdentifierTypesSpecificationWithInvalidGroupName(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
@@ -281,7 +284,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetIdentifierTypesJsonSchema()
+    public function testGetIdentifierTypesJsonSchema(): void
     {
         foreach (['default', null] as $group_name) {
             $this->assertInternalType(
@@ -303,7 +306,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testIdentifierTypesUsingSchemaValidator()
+    public function testIdentifierTypesUsingSchemaValidator(): void
     {
         foreach (['default', null] as $group_name) {
             $identifier_types = Json::decode(\file_get_contents($this->instance::getRootDirectoryPath(
@@ -324,7 +327,7 @@ class SpecificationsTest extends AbstractTestCase
      *
      * @return void
      */
-    public function testVersion()
+    public function testVersion(): void
     {
         $this->assertSame(
             $version = Versions::getVersion($this->instance::SELF_PACKAGE_NAME),
@@ -337,7 +340,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testFieldsListAndReportSchemaAreSame()
+    public function testFieldsListAndReportSchemaAreSame(): void
     {
         $fields = $this->instance::getFieldsSpecification();
         $schema = $this->instance::getReportJsonSchema(null, true);
@@ -383,7 +386,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetFieldsSpecificationWithInvalidGroupName()
+    public function testGetFieldsSpecificationWithInvalidGroupName(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
@@ -394,7 +397,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetSourcesSpecification()
+    public function testGetSourcesSpecification(): void
     {
         foreach (['default', null] as $group_name) {
             $result = $this->instance::getSourcesSpecification($group_name);
@@ -427,7 +430,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetSourcesJsonSchema()
+    public function testGetSourcesJsonSchema(): void
     {
         foreach (['default', null] as $group_name) {
             $this->assertInternalType(
@@ -449,7 +452,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testSourcesUsingSchemaValidator()
+    public function testSourcesUsingSchemaValidator(): void
     {
         foreach (['default', null] as $group_name) {
             $identifier_types = Json::decode(\file_get_contents($this->instance::getRootDirectoryPath(
@@ -468,7 +471,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehiclesMarksSpecification()
+    public function testGetVehiclesMarksSpecification(): void
     {
         foreach (['default', null] as $group_name) {
             $result = $this->instance::getVehicleMarksSpecification($group_name);
@@ -501,7 +504,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehicleModelsSpecification()
+    public function testGetVehicleModelsSpecification(): void
     {
         foreach (['default', null] as $group_name) {
             $result = $this->instance::getVehicleModelsSpecification($group_name);
@@ -535,7 +538,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehicleModelsByTypeSpecification()
+    public function testGetVehicleModelsByTypeSpecification(): void
     {
         foreach (['default', null] as $group_name) {
             foreach ($this->getVehicleTypeAliasByIdMap() as $vehicle_type => $alias) {
@@ -569,7 +572,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehicleModelsByTypeSpecificationException()
+    public function testGetVehicleModelsByTypeSpecificationException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown vehicle type identifier [UNKNOWN]');
@@ -580,7 +583,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehicleTypeAliasById()
+    public function testGetVehicleTypeAliasById(): void
     {
         $method_name = 'getVehicleTypeAliasById';
         $method      = $this->getNonPublicMethod(get_class($this->instance), $method_name);
@@ -595,7 +598,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehicleTypeAliasByIdException()
+    public function testGetVehicleTypeAliasByIdException(): void
     {
         $method_name = 'getVehicleTypeAliasById';
         $method      = $this->getNonPublicMethod(get_class($this->instance), $method_name);
@@ -606,7 +609,7 @@ class SpecificationsTest extends AbstractTestCase
         $method->invokeArgs($this->instance, ['UNKNOWN', null]);
     }
 
-    public function testGetVehicleModelsSpecificationFilePath()
+    public function testGetVehicleModelsSpecificationFilePath(): void
     {
         $method_name = 'getVehicleModelsSpecificationFilePath';
         $method      = $this->getNonPublicMethod(get_class($this->instance), $method_name);
@@ -618,7 +621,7 @@ class SpecificationsTest extends AbstractTestCase
         }
     }
 
-    public function testGetVehicleModelsSpecificationFilePathException()
+    public function testGetVehicleModelsSpecificationFilePathException(): void
     {
         $method_name = 'getVehicleModelsSpecificationFilePath';
         $method      = $this->getNonPublicMethod(get_class($this->instance), $method_name);
@@ -632,7 +635,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetVehicleTypesSpecification()
+    public function testGetVehicleTypesSpecification(): void
     {
         foreach (['default', null] as $group_name) {
             $result = $this->instance::getVehicleTypesSpecification($group_name);
@@ -665,7 +668,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetSourcesSpecificationWithInvalidGroupName()
+    public function testGetSourcesSpecificationWithInvalidGroupName(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessageRegExp('~file.+was not found~i');
@@ -676,7 +679,7 @@ class SpecificationsTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testGetJsonFileContent()
+    public function testGetJsonFileContent(): void
     {
         $method_name = 'getJsonFileContent';
         $method      = $this->getNonPublicMethod(get_class($this->instance), $method_name);
@@ -696,7 +699,7 @@ class SpecificationsTest extends AbstractTestCase
      *
      * @return array
      */
-    protected function getVehicleTypeAliasByIdMap()
+    protected function getVehicleTypeAliasByIdMap(): array
     {
         return [
             'ID_TYPE_AGRICULTURAL' => 'agricultural',
@@ -735,7 +738,7 @@ class SpecificationsTest extends AbstractTestCase
      *
      * @return array
      */
-    protected function getVehicleModelsFilePathByTypeId($group_name = null)
+    protected function getVehicleModelsFilePathByTypeId($group_name = null): array
     {
         $group_name = $group_name ?? 'default';
 
@@ -760,9 +763,9 @@ class SpecificationsTest extends AbstractTestCase
      * @param string $class_name
      * @param string $method_name
      *
-     * @return \ReflectionMethod
+     * @return ReflectionMethod
      */
-    protected function getNonPublicMethod($class_name, $method_name)
+    protected function getNonPublicMethod($class_name, $method_name): ReflectionMethod
     {
         $class  = new ReflectionClass($class_name);
         $method = $class->getMethod($method_name);

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Tests;
 

--- a/sdk/php/tests/Structures/AbstractStructureTestCase.php
+++ b/sdk/php/tests/Structures/AbstractStructureTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Avtocod\Specifications\Tests\Structures;
 

--- a/sdk/php/tests/Structures/AbstractStructureTestCase.php
+++ b/sdk/php/tests/Structures/AbstractStructureTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Avtocod\Specifications\Tests\Structures;
 
 use LogicException;
@@ -16,7 +18,7 @@ abstract class AbstractStructureTestCase extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -26,7 +28,7 @@ abstract class AbstractStructureTestCase extends AbstractTestCase
     /**
      * Test to array converting without any data.
      */
-    public function testBasicToArray()
+    public function testBasicToArray(): void
     {
         $this->assertInternalType('array', $this->instance->toArray());
         $this->assertInternalType('string', $this->instance->toJson());
@@ -37,12 +39,12 @@ abstract class AbstractStructureTestCase extends AbstractTestCase
      *
      * @return void
      */
-    abstract public function testArrayAccess();
+    abstract public function testArrayAccess(): void;
 
     /**
      * @return void
      */
-    public function testArrayAccessExceptionOnChanging()
+    public function testArrayAccessExceptionOnChanging(): void
     {
         $this->expectException(LogicException::class);
 
@@ -52,7 +54,7 @@ abstract class AbstractStructureTestCase extends AbstractTestCase
     /**
      * @return void
      */
-    public function testIterator()
+    public function testIterator(): void
     {
         $this->assertInstanceOf(\ArrayIterator::class, $this->instance->getIterator());
 
@@ -79,7 +81,7 @@ abstract class AbstractStructureTestCase extends AbstractTestCase
     /**
      * @return void
      */
-    public function testArrayAccessExceptionOnUnset()
+    public function testArrayAccessExceptionOnUnset(): void
     {
         $this->expectException(LogicException::class);
 
@@ -91,7 +93,7 @@ abstract class AbstractStructureTestCase extends AbstractTestCase
      *
      * @return void
      */
-    abstract public function testConfigure();
+    abstract public function testConfigure(): void;
 
     /**
      * Tested instance factory.

--- a/sdk/php/tests/Structures/FieldTest.php
+++ b/sdk/php/tests/Structures/FieldTest.php
@@ -14,7 +14,7 @@ class FieldTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $this->instance = $this->factory($input = [
             'path'        => $path = 'some path',
@@ -34,7 +34,7 @@ class FieldTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testConfigureWithNulls()
+    public function testConfigureWithNulls(): void
     {
         $this->instance = $this->factory($input = [
             'path'        => null,
@@ -52,7 +52,7 @@ class FieldTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $this->instance = $this->factory([
             'path' => $path = 'some path',
@@ -67,7 +67,7 @@ class FieldTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testNesting()
+    public function testNesting(): void
     {
         $this->instance = $this->factory([
             'path' => 'some path',
@@ -94,7 +94,7 @@ class FieldTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testPathParts()
+    public function testPathParts(): void
     {
         $this->instance = $this->factory([
             'path' => 'some.path[].included',
@@ -118,7 +118,7 @@ class FieldTest extends AbstractStructureTestCase
      *
      * @return Field
      */
-    protected function factory(...$arguments)
+    protected function factory(...$arguments): Field
     {
         return new Field(...$arguments);
     }

--- a/sdk/php/tests/Structures/IdentifierTypeTest.php
+++ b/sdk/php/tests/Structures/IdentifierTypeTest.php
@@ -14,7 +14,7 @@ class IdentifierTypeTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $this->instance = $this->factory($input = [
             'description' => $description = 'some description',
@@ -30,7 +30,7 @@ class IdentifierTypeTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testConfigureWithNulls()
+    public function testConfigureWithNulls(): void
     {
         $this->instance = $this->factory($input = [
             'description' => null,
@@ -44,7 +44,7 @@ class IdentifierTypeTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $this->instance = $this->factory([
             'type' => $type = 'some type',
@@ -61,7 +61,7 @@ class IdentifierTypeTest extends AbstractStructureTestCase
      *
      * @return IdentifierType
      */
-    protected function factory(...$arguments)
+    protected function factory(...$arguments): IdentifierType
     {
         return new IdentifierType(...$arguments);
     }

--- a/sdk/php/tests/Structures/SourceTest.php
+++ b/sdk/php/tests/Structures/SourceTest.php
@@ -14,7 +14,7 @@ class SourceTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $this->instance = $this->factory($input = [
             'description' => $description = 'some description',
@@ -30,7 +30,7 @@ class SourceTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testConfigureWithNulls()
+    public function testConfigureWithNulls(): void
     {
         $this->instance = $this->factory($input = [
             'description' => null,
@@ -44,7 +44,7 @@ class SourceTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $this->instance = $this->factory([
             'name' => $name = 'some name',
@@ -61,7 +61,7 @@ class SourceTest extends AbstractStructureTestCase
      *
      * @return Source
      */
-    protected function factory(...$arguments)
+    protected function factory(...$arguments): Source
     {
         return new Source(...$arguments);
     }

--- a/sdk/php/tests/Structures/VehicleMarkTest.php
+++ b/sdk/php/tests/Structures/VehicleMarkTest.php
@@ -14,7 +14,7 @@ class VehicleMarkTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $this->instance = $this->factory($input = [
             'id'   => $description = 'some description',
@@ -30,7 +30,7 @@ class VehicleMarkTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testConfigureWithNulls()
+    public function testConfigureWithNulls(): void
     {
         $this->instance = $this->factory($input = [
             'id'   => null,
@@ -44,7 +44,7 @@ class VehicleMarkTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $this->instance = $this->factory([
             'name' => $name = 'some name',
@@ -61,7 +61,7 @@ class VehicleMarkTest extends AbstractStructureTestCase
      *
      * @return VehicleMark
      */
-    protected function factory(...$arguments)
+    protected function factory(...$arguments): VehicleMark
     {
         return new VehicleMark(...$arguments);
     }

--- a/sdk/php/tests/Structures/VehicleModelTest.php
+++ b/sdk/php/tests/Structures/VehicleModelTest.php
@@ -14,7 +14,7 @@ class VehicleModelTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $this->instance = $this->factory($input = [
             'id'      => $description = 'some description',
@@ -32,7 +32,7 @@ class VehicleModelTest extends AbstractStructureTestCase
     /**
      * @return void
      */
-    public function testConfigureWithNulls()
+    public function testConfigureWithNulls(): void
     {
         $this->instance = $this->factory($input = [
             'id'      => null,
@@ -48,7 +48,7 @@ class VehicleModelTest extends AbstractStructureTestCase
     /**
      * {@inheritdoc}
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $this->instance = $this->factory([
             'name' => $name = 'some name',
@@ -65,7 +65,7 @@ class VehicleModelTest extends AbstractStructureTestCase
      *
      * @return VehicleModel
      */
-    protected function factory(...$arguments)
+    protected function factory(...$arguments): VehicleModel
     {
         return new VehicleModel(...$arguments);
     }

--- a/sdk/php/tests/Structures/VehicleTypeTest.php
+++ b/sdk/php/tests/Structures/VehicleTypeTest.php
@@ -16,7 +16,7 @@ class VehicleTypeTest extends AbstractStructureTestCase
      *
      * @return void
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $this->instance = $this->factory($input = [
             'id'           => $id_type = 'some id',
@@ -36,7 +36,7 @@ class VehicleTypeTest extends AbstractStructureTestCase
      *
      * @return void
      */
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $this->instance = $this->factory($input = [
             'id'           => null,

--- a/sdk/php/tests/bootstrap.php
+++ b/sdk/php/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+ini_set('error_reporting', E_ALL);
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');


### PR DESCRIPTION
Вопрос                | Ответ
--------------------- | ---
Это исправление?      | Нет
Это новый функционал? | Нет

## Описание

### Changed

- **PHP SDK** minimal `PHP` version now is `7.1.3`
- **PHP SDK** maximal `illuminate/support` dependency version now is `5.8.x`
- **PHP SDK** type-hinting in tests updated

## Чек-лист

- [x] Мой код соответствует общему стилю этого проекта
- [x] Я самостоятельно просмотрел свой код
- [ ] Я оставил комментарии в своём коде там, где это необходимо
- [ ] Я написал тесты на весь код, что был мною написан
- [x] Я внёс соответствующие изменения в файл [CHANGELOG.md](https://github.com/avtocod/specs/blob/master/CHANGELOG.md)