### PR TITLE
Added source "dtp.registry"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Source `dtp.registry` [#105]
+
+### Changed
+
+- Field with path `accidents.history.items[].number` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].accident.date` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].type` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].state` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].vehicle.brand.name` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].vehicle.model.name` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].vehicle.year` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].geo` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].damage.points` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].damage.codes` also fillable by `dtp.registry` [#105]
+- Field with path `accidents.history.items[].actuality.date` also fillable by `dtp.registry` [#105]
+
+[#105]:https://github.com/avtocod/specs/issues/105
+
 ## v3.18.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -1072,7 +1072,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1082,7 +1083,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1092,7 +1094,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1102,7 +1105,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1122,7 +1126,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1132,7 +1137,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1142,7 +1148,8 @@
             "integer"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1152,7 +1159,8 @@
             "object"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1162,7 +1170,8 @@
             "array"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1172,7 +1181,8 @@
             "array"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {
@@ -1192,7 +1202,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -4382,7 +4382,8 @@
                                             "000043057"
                                         ],
                                         "fillable_by": [
-                                            "gibdd.dtp"
+                                            "gibdd.dtp",
+                                            "dtp.registry"
                                         ]
                                     },
                                     "accident": {
@@ -4403,7 +4404,8 @@
                                                     "1978-02-14 05:24:00"
                                                 ],
                                                 "fillable_by": [
-                                                    "gibdd.dtp"
+                                                    "gibdd.dtp",
+                                                    "dtp.registry"
                                                 ]
                                             }
                                         }
@@ -4419,7 +4421,8 @@
                                             "Наезд на стоящее ТС"
                                         ],
                                         "fillable_by": [
-                                            "gibdd.dtp"
+                                            "gibdd.dtp",
+                                            "dtp.registry"
                                         ]
                                     },
                                     "state": {
@@ -4432,7 +4435,8 @@
                                             "Повреждено"
                                         ],
                                         "fillable_by": [
-                                            "gibdd.dtp"
+                                            "gibdd.dtp",
+                                            "dtp.registry"
                                         ]
                                     },
                                     "org": {
@@ -4494,7 +4498,8 @@
                                                     null
                                                 ],
                                                 "fillable_by": [
-                                                    "gibdd.dtp"
+                                                    "gibdd.dtp",
+                                                    "dtp.registry"
                                                 ]
                                             },
                                             "codes": {
@@ -4519,7 +4524,8 @@
                                                     null
                                                 ],
                                                 "fillable_by": [
-                                                    "gibdd.dtp"
+                                                    "gibdd.dtp",
+                                                    "dtp.registry"
                                                 ]
                                             }
                                         }
@@ -4542,7 +4548,8 @@
                                                             "Opel"
                                                         ],
                                                         "fillable_by": [
-                                                            "gibdd.dtp"
+                                                            "gibdd.dtp",
+                                                            "dtp.registry"
                                                         ]
                                                     }
                                                 }
@@ -4561,7 +4568,8 @@
                                                             "MONTEREY"
                                                         ],
                                                         "fillable_by": [
-                                                            "gibdd.dtp"
+                                                            "gibdd.dtp",
+                                                            "dtp.registry"
                                                         ]
                                                     }
                                                 }
@@ -4577,7 +4585,8 @@
                                                     2004
                                                 ],
                                                 "fillable_by": [
-                                                    "gibdd.dtp"
+                                                    "gibdd.dtp",
+                                                    "dtp.registry"
                                                 ]
                                             }
                                         }
@@ -4593,7 +4602,8 @@
                                             }
                                         ],
                                         "fillable_by": [
-                                            "gibdd.dtp"
+                                            "gibdd.dtp",
+                                            "dtp.registry"
                                         ]
                                     },
                                     "actuality": {
@@ -4614,7 +4624,8 @@
                                                     "2020-02-11 05:24:00"
                                                 ],
                                                 "fillable_by": [
-                                                    "gibdd.dtp"
+                                                    "gibdd.dtp",
+                                                    "dtp.registry"
                                                 ]
                                             }
                                         }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -163,5 +163,10 @@
         "name": "fines.alt",
         "description": "Данные о штрафах, оформленных на ТС, альтернативный источник",
         "enabled": true
+    },
+    {
+        "name": "dtp.registry",
+        "description": "Данные о ДТП зарегистрированных в базе ГИБДД (история ДТП)",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

Added source `dtp.registry`.

This fileds are fiilable now by `dtp.registry`:

- `accidents.history.items[].number`
- `accidents.history.items[].accident.date`
- `accidents.history.items[].type`
- `accidents.history.items[].state`
- `accidents.history.items[].vehicle.brand.name`
- `accidents.history.items[].vehicle.model.name`
- `accidents.history.items[].vehicle.year`
- `accidents.history.items[].geo`
- `accidents.history.items[].damage.points`
- `accidents.history.items[].damage.codes`
- `accidents.history.items[].actuality.date`

Closes #105 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avtocod/specs/blob/master/CHANGELOG.md) file


