### PR TITLE
Add check that all report fillable_by source are exist in field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.23.1
+
+### Changed
+
+- `SpecificationsTest::testFieldsListAndReportSchemaAreSame` improved [#111]
+
+### Fixed
+
+- Field with path `identifiers.vehicle.body` also fallible by `gibdd.history` source in `./fields/default/fields_list.json` [#111]
+
+[#111]:https://github.com/avtocod/specs/issues/111
+
 ## v3.23.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -63,6 +63,7 @@
         "fillable_by": [
             "base",
             "base.ext",
+            "gibdd.history",
             "base.taxi",
             "base.alt",
             "regactions.registry"

--- a/sdk/php/tests/SpecificationsTest.php
+++ b/sdk/php/tests/SpecificationsTest.php
@@ -377,6 +377,14 @@ class SpecificationsTest extends AbstractTestCase
                     "Schema should contains same 'fillable_by' for field with path {$field->getPath()} (from 'fields_list.json' file)"
                 );
             }
+
+            foreach ($schema_field_data['fillable_by'] as $source_name) {
+                $this->assertContains(
+                    $source_name,
+                    $field->getFillableBy(),
+                    "Schema should contains existing 'fillable_by' for field with path {$field->getPath()} (from 'fields_list.json' file)"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

### Changed

- `SpecificationsTest::testFieldsListAndReportSchemaAreSame` improved [#111]

### Fixed

- Field with path `identifiers.vehicle.body` also fallible by `gibdd.history` source in `./fields/default/fields_list.json` [#111]

[#111]:https://github.com/avtocod/specs/issues/111

Closes #111 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avtocod/specs/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
