### PR TITLE
Fixed oneOf keyword on anyOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Fixed
 
-- Fixed `oneOf` keyword on `anyOf` for `pledges.items[].pledgors[].name`, `pledges.items[].pledgees[].name` in `./reports/default/json-schema.json`
+- Replaced `oneOf` keyword with `anyOf` for `pledges.items[].pledgors[].name`, `pledges.items[].pledgees[].name` in `./reports/default/json-schema.json`
 
 ## v3.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.25.1
+
+### Fixed
+
+- Fixed `oneOf` keyword on `anyOf` in `./reports/default/json-schema.json`
+
 ## v3.25.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## v3.25.1
 
+### Added
+
+- Example for `pledges` block with `REFUSE` values for `pledges.items[].pledgors[].name`, `pledges.items[].pledgees[].name`
+
 ### Fixed
 
-- Fixed `oneOf` keyword on `anyOf` in `./reports/default/json-schema.json`
+- Fixed `oneOf` keyword on `anyOf` for `pledges.items[].pledgors[].name`, `pledges.items[].pledgees[].name` in `./reports/default/json-schema.json`
 
 ## v3.25.0
 

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -582,6 +582,29 @@
                 "type": "Возникновение",
                 "in_pledge": true,
                 "data": null
+            },
+            {
+                "date": {
+                    "event": "2013-06-27 00:00:00"
+                },
+                "number": "2013-001-406288-623\/242",
+                "pledgors": [
+                    {
+                        "name": "REFUSE",
+                        "type": "PERSON",
+                        "dob": "1983-08-31"
+                    }
+                ],
+                "pledgees": [
+                    {
+                        "name": "REFUSE",
+                        "type": "LEGAL",
+                        "dob": null
+                    }
+                ],
+                "type": "Исключение",
+                "in_pledge": false,
+                "data": null
             }
         ],
         "count": 1

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -3966,7 +3966,7 @@
                                     "properties": {
                                         "name": {
                                             "description": "Залогодатель (имя)",
-                                            "oneOf": [
+                                            "anyOf": [
                                                 {
                                                     "type": [
                                                         "string",
@@ -4040,7 +4040,7 @@
                                     "properties": {
                                         "name": {
                                             "description": "Имя залогодержателя",
-                                            "oneOf": [
+                                            "anyOf": [
                                                 {
                                                     "type": [
                                                         "string",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

Исправлено ключевое слово с `oneOf` на `anyOf` в полях спецификации отчёта `pledges.items[].pledgors[].name`, `pledges.items[].pledgees[].name`



## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avtocod/specs/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
