### PR TITLE
Added sources to owneship fields fillable by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.42.0
+
+### Changed
+
+- Field with path `ownership.history.items[].date.start` also fillable by `base`, `base.ext`
+- Field with path `ownership.history.items[].date.end` also fillable by `base`, `base.ext`
+- Field with path `ownership.history.items[].owner.type` also fillable by `base`, `base.ext`
+- Field with path `ownership.history.items[].last_operation.code` also fillable by `base`, `base.ext`, `base.alt`
+- Field with path `ownership.history.items[].last_operation.description` also fillable by `base`, `base.ext`, `base.alt`
+
 ## v3.41.1
 
 ### Fixed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -1022,6 +1022,8 @@
         ],
         "fillable_by": [
             "gibdd.history",
+            "base",
+            "base.ext",
             "base.alt",
             "regactions.registry"
         ]
@@ -1034,6 +1036,8 @@
         ],
         "fillable_by": [
             "gibdd.history",
+            "base",
+            "base.ext",
             "base.alt"
         ]
     },
@@ -1045,6 +1049,8 @@
         ],
         "fillable_by": [
             "gibdd.history",
+            "base",
+            "base.ext",
             "base.alt",
             "regactions.registry"
         ]
@@ -1056,6 +1062,9 @@
             "string"
         ],
         "fillable_by": [
+            "base",
+            "base.ext",
+            "base.alt",
             "gibdd.history"
         ]
     },
@@ -1066,6 +1075,9 @@
             "string"
         ],
         "fillable_by": [
+            "base",
+            "base.ext",
+            "base.alt",
             "gibdd.history"
         ]
     },

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -6045,6 +6045,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "gibdd.history",
+                                                    "base",
+                                                    "base.ext",
                                                     "base.alt",
                                                     "regactions.registry"
                                                 ]
@@ -6064,6 +6066,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "gibdd.history",
+                                                    "base",
+                                                    "base.ext",
                                                     "base.alt"
                                                 ]
                                             }
@@ -6092,6 +6096,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "gibdd.history",
+                                                    "base",
+                                                    "base.ext",
                                                     "base.alt",
                                                     "regactions.registry"
                                                 ]
@@ -6112,6 +6118,9 @@
                                                     "11"
                                                 ],
                                                 "fillable_by": [
+                                                    "base",
+                                                    "base.ext",
+                                                    "base.alt",
                                                     "gibdd.history"
                                                 ]
                                             },
@@ -6125,6 +6134,9 @@
                                                     "Первичная регистрация"
                                                 ],
                                                 "fillable_by": [
+                                                    "base",
+                                                    "base.ext",
+                                                    "base.alt",
                                                     "gibdd.history"
                                                 ]
                                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

### Changed

- Field with path `ownership.history.items[].date.start` also fillable by `base`, `base.ext`
- Field with path `ownership.history.items[].date.end` also fillable by `base`, `base.ext`
- Field with path `ownership.history.items[].owner.type` also fillable by `base`, `base.ext`
- Field with path `ownership.history.items[].last_operation.code` also fillable by `base`, `base.ext`, `base.alt`
- Field with path `ownership.history.items[].last_operation.description` also fillable by `base`, `base.ext`, `base.alt`

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
