### PR TITLE
Fix accidents.history.items[].damage.raw field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Field with path `accidents.history.items[].damage.raw` also fillable by `gibdd.dtp`
+- Field with path `accidents.history.items[].damage.raw` is not fillable by `base.moscow` source now
+
 ## v3.71.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -2466,7 +2466,7 @@
             "string"
         ],
         "fillable_by": [
-            "base.moscow"
+            "gibdd.dtp"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -7191,7 +7191,7 @@
                                                     "Перед справа, перед слева"
                                                 ],
                                                 "fillable_by": [
-                                                    "base.moscow"
+                                                    "gibdd.dtp"
                                                 ]
                                             },
                                             "points": {


### PR DESCRIPTION
## Description

### Changed

- Field with path `accidents.history.items[].damage.raw` also fillable by `gibdd.dtp`
- Field with path `accidents.history.items[].damage.raw` is not fillable by `base.moscow` source now

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
