### PR TITLE
Extend enum with 'UNKNOWN' value for some fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Extend enum with `UNKNOWN` value for field `insurance.osago.items[].insurant.type` in `./reports/default/json-schema.json`
-- Extend enum with `UNKNOWN` value for field `insurance.osago.items[].owner.type` in `./reports/default/json-schema.json`
+- Extend enum with `UNKNOWN` value for fields `insurance.osago.items[].insurant.type`, `insurance.osago.items[].owner.type` in `./reports/default/json-schema.json`
 
 ## v3.77.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Extend enum with `UNKNOWN` value for field `insurance.osago.items[].insurant.type` in `./reports/default/json-schema.json`
+- Extend enum with `UNKNOWN` value for field `insurance.osago.items[].owner.type` in `./reports/default/json-schema.json`
+
 ## v3.77.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -2125,7 +2125,7 @@
     },
     {
         "path": "insurance.osago.items[].insurant.type",
-        "description": "ОСАГО: Тип страхователя [PERSON, LEGAL]",
+        "description": "ОСАГО: Тип страхователя [PERSON, LEGAL, UNKNOWN]",
         "types": [
             "string"
         ],
@@ -2173,7 +2173,7 @@
     },
     {
         "path": "insurance.osago.items[].owner.type",
-        "description": "ОСАГО: Тип владельца ТС [PERSON, LEGAL]",
+        "description": "ОСАГО: Тип владельца ТС [PERSON, LEGAL, UNKNOWN]",
         "types": [
             "string"
         ],

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -6936,7 +6936,7 @@
                                         "additionalProperties": false,
                                         "properties": {
                                             "type": {
-                                                "description": "Тип страхователя [PERSON, LEGAL]",
+                                                "description": "Тип страхователя [PERSON, LEGAL, UNKNOWN]",
                                                 "type": [
                                                     "string",
                                                     "null"
@@ -6944,6 +6944,7 @@
                                                 "enum": [
                                                     "PERSON",
                                                     "LEGAL",
+                                                    "UNKNOWN",
                                                     null
                                                 ],
                                                 "examples": [
@@ -7015,7 +7016,7 @@
                                         "additionalProperties": false,
                                         "properties": {
                                             "type": {
-                                                "description": "Тип владельца ТС [PERSON, LEGAL]",
+                                                "description": "Тип владельца ТС [PERSON, LEGAL, UNKNOWN]",
                                                 "type": [
                                                     "string",
                                                     "null"
@@ -7023,6 +7024,7 @@
                                                 "enum": [
                                                     "PERSON",
                                                     "LEGAL",
+                                                    "UNKNOWN",
                                                     null
                                                 ],
                                                 "examples": [


### PR DESCRIPTION
## Description

### Changed

- Extend enum with `UNKNOWN` value for field `insurance.osago.items[].insurant.type` in `./reports/default/json-schema.json`
- Extend enum with `UNKNOWN` value for field `insurance.osago.items[].owner.type` in `./reports/default/json-schema.json`

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
