### PR TITLE
Remove base.registry and base.registry.retry from tech_data.model.nam…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Field with path `tech_data.model.name.original` not fillable by `base.registry` and `base.registry.retry` anymore
+
 ## v3.95.0
 
 ### Changed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -276,9 +276,7 @@
         "fillable_by": [
             "gibdd.history",
             "gibdd.eaisto",
-            "gibdd.diagnostic.cards",
-            "base.registry",
-            "base.registry.retry"
+            "gibdd.diagnostic.cards"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -809,9 +809,7 @@
                                     "fillable_by": [
                                         "gibdd.history",
                                         "gibdd.eaisto",
-                                        "gibdd.diagnostic.cards",
-                                        "base.registry",
-                                        "base.registry.retry"
+                                        "gibdd.diagnostic.cards"
                                     ]
                                 },
                                 "normalized": {


### PR DESCRIPTION
…e.original field

## Description

### Changed

- Field with path `tech_data.model.name.original` not fillable by `base.registry` and `base.registry.retry` anymore

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
