### PR TITLE
Draft: add fillable by for osago.registry fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Field with path `insurance.osago.items[].owner.tin` also fillable by `osago.registry`
+- Field with path `insurance.osago.items[].number` also fillable by `osago.registry`
+
 ## v3.98.0
 
 ### Changed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -1816,7 +1816,8 @@
         "fillable_by": [
             "rsaosago.base",
             "ramiosago.base",
-            "ramiosago.base.ext"
+            "ramiosago.base.ext",
+            "osago.registry"
         ]
     },
     {
@@ -2375,7 +2376,8 @@
             "ramiosago.base.ext",
             "rsaosago.base",
             "rsaosago.base.ext",
-            "rsaosago.base.history"
+            "rsaosago.base.history",
+            "osago.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -6507,7 +6507,8 @@
                                         "fillable_by": [
                                             "rsaosago.base",
                                             "ramiosago.base",
-                                            "ramiosago.base.ext"
+                                            "ramiosago.base.ext",
+                                            "osago.registry"
                                         ]
                                     },
                                     "insurer": {
@@ -7369,7 +7370,8 @@
                                                     "ramiosago.base.ext",
                                                     "rsaosago.base",
                                                     "rsaosago.base.ext",
-                                                    "rsaosago.base.history"
+                                                    "rsaosago.base.history",
+                                                    "osago.registry"
                                                 ]
                                             }
                                         }


### PR DESCRIPTION
## Description

### Changed

- Field with path `insurance.osago.items[].owner.tin` also fillable by `osago.registry`
- Field with path `insurance.osago.items[].number` also fillable by `osago.registry`

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
