### PR TITLE
Drafr: Rename accidents.insurance fields description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Description for a field with path `accidents.insurance.date.update` in `./fields/default/fields_list.json`
+- Description for a field with path `accidents.insurance.items[].date.event` in `./fields/default/fields_list.json`
+- Description for a field with path `accidents.insurance.items[].insurer.name` in `./fields/default/fields_list.json`
+- Description for a field with path `accidents.insurance.items[].policy.series` in `./fields/default/fields_list.json`
+- Description for a field with path `accidents.insurance.items[].policy.number` in `./fields/default/fields_list.json`
+- Description for a field with path `accidents.insurance.items[].actuality.date` in `./fields/default/fields_list.json`
+
 ## v3.111.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -3172,7 +3172,7 @@
     },
     {
         "path": "accidents.insurance.date.update",
-        "description": "История повреждений из страховых компаний: Дата обновления данных",
+        "description": "История страховых случаев: Дата обновления данных",
         "types": [
             "string"
         ],
@@ -3183,7 +3183,7 @@
     },
     {
         "path": "accidents.insurance.items[].date.event",
-        "description": "История повреждений из страховых компаний: Дата происшествия",
+        "description": "История страховых случаев: Дата происшествия",
         "types": [
             "string"
         ],
@@ -3194,7 +3194,7 @@
     },
     {
         "path": "accidents.insurance.items[].insurer.name",
-        "description": "История повреждений из страховых компаний: Наименование страховой компании",
+        "description": "История страховых случаев: Наименование страховой компании",
         "types": [
             "string"
         ],
@@ -3205,7 +3205,7 @@
     },
     {
         "path": "accidents.insurance.items[].policy.series",
-        "description": "История повреждений из страховых компаний: Серия страхового полиса",
+        "description": "История страховых случаев: Серия страхового полиса",
         "types": [
             "string"
         ],
@@ -3216,7 +3216,7 @@
     },
     {
         "path": "accidents.insurance.items[].policy.number",
-        "description": "История повреждений из страховых компаний: Номер страхового полиса",
+        "description": "История страховых случаев: Номер страхового полиса",
         "types": [
             "string"
         ],
@@ -3227,7 +3227,7 @@
     },
     {
         "path": "accidents.insurance.items[].actuality.date",
-        "description": "История повреждений из страховых компаний: Дата актуальности данных",
+        "description": "История страховых случаев: Дата актуальности данных",
         "types": [
             "string"
         ],

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -8572,7 +8572,7 @@
                     }
                 },
                 "insurance": {
-                    "description": "История повреждений из страховых компаний",
+                    "description": "История страховых случаев",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {


### PR DESCRIPTION
## Description

### Changed

- Description for a field with path `accidents.insurance.date.update` in `./fields/default/fields_list.json`
- Description for a field with path `accidents.insurance.items[].date.event` in `./fields/default/fields_list.json`
- Description for a field with path `accidents.insurance.items[].insurer.name` in `./fields/default/fields_list.json`
- Description for a field with path `accidents.insurance.items[].policy.series` in `./fields/default/fields_list.json`
- Description for a field with path `accidents.insurance.items[].policy.number` in `./fields/default/fields_list.json`
- Description for a field with path `accidents.insurance.items[].actuality.date` in `./fields/default/fields_list.json`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
