### PR TITLE
Draft: Fix base.basalt fills date.update fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Fixed
+
+- Field with path `tech_data.date.update` also fillable by `base.basalt`
+- Field with path `customs.history.date.update` also fillable by `base.basalt`
+- Field with path `ownership.history.date.update` also fillable by `base.basalt`
+- Field with path `registration_actions.date.update` also fillable by `base.basalt`
+- Field with path `restrictions.registration_actions.date.update` also fillable by `base.basalt`
+
 ## v3.120.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -853,6 +853,7 @@
             "customs.base",
             "gibdd.eaisto",
             "base.alt",
+            "base.basalt",
             "regactions.registry",
             "gibdd.diagnostic.cards",
             "eaisto.registry",
@@ -1795,6 +1796,7 @@
             "base",
             "base.ext",
             "base.alt",
+            "base.basalt",
             "regactions.registry",
             "gibdd.history.registry"
         ]
@@ -2044,6 +2046,7 @@
             "base",
             "base.ext",
             "base.alt",
+            "base.basalt",
             "regactions.registry",
             "gibdd.history.registry"
         ]
@@ -3604,7 +3607,8 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.restrict"
+            "gibdd.restrict",
+            "base.basalt"
         ]
     },
     {
@@ -4343,7 +4347,8 @@
             "string"
         ],
         "fillable_by": [
-            "customs.base"
+            "customs.base",
+            "base.basalt"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -1742,6 +1742,7 @@
                                 "customs.base",
                                 "gibdd.eaisto",
                                 "base.alt",
+                                "base.basalt",
                                 "regactions.registry",
                                 "eaisto.registry",
                                 "gibdd.diagnostic.cards",
@@ -3515,6 +3516,7 @@
                                 "base",
                                 "base.ext",
                                 "base.alt",
+                                "base.basalt",
                                 "regactions.registry",
                                 "gibdd.history.registry"
                             ]
@@ -5850,7 +5852,8 @@
                                         "2020-02-11 22:10:00"
                                     ],
                                     "fillable_by": [
-                                        "customs.base"
+                                        "customs.base",
+                                        "base.basalt"
                                     ]
                                 }
                             }
@@ -9163,7 +9166,8 @@
                                         "2015-07-13 00:00:00"
                                     ],
                                     "fillable_by": [
-                                        "gibdd.restrict"
+                                        "gibdd.restrict",
+                                        "base.basalt"
                                     ]
                                 }
                             }
@@ -10145,6 +10149,7 @@
                                         "base",
                                         "base.ext",
                                         "base.alt",
+                                        "base.basalt",
                                         "regactions.registry",
                                         "gibdd.history.registry"
                                     ]


### PR DESCRIPTION
## Description

### Fixed

- Field with path `tech_data.date.update` also fillable by `base.basalt`
- Field with path `customs.history.date.update` also fillable by `base.basalt`
- Field with path `ownership.history.date.update` also fillable by `base.basalt`
- Field with path `registration_actions.date.update` also fillable by `base.basalt`
- Field with path `restrictions.registration_actions.date.update` also fillable by `base.basalt`