### PR TITLE
Draft: Add filled_by for fines.base fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Field with path `fines.items[].vendor.type` also fillable by `fines.base`
+- Field with path `fines.items[].payer.name` also fillable by `fines.base`
+- Field with path `fines.items[].payer.identifier.type` also fillable by `fines.base`
+- Field with path `fines.items[].payer.identifier.number` also fillable by `fines.base`
+- Field with path `fines.items[].fssp.enforcement_proceeding.number` also fillable by `fines.base`
+- Field with path `fines.items[].fssp.enforcement_proceeding.contact` also fillable by `fines.base`
+
 ## v3.125.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -4845,7 +4845,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.registry"
+            "fines.registry",
+            "fines.base"
         ]
     },
     {
@@ -5109,7 +5110,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.registry"
+            "fines.registry",
+            "fines.base"
         ]
     },
     {
@@ -5119,7 +5121,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.registry"
+            "fines.registry",
+            "fines.base"
         ]
     },
     {
@@ -5151,7 +5154,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.registry"
+            "fines.registry",
+            "fines.base"
         ]
     },
     {
@@ -5161,7 +5165,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.registry"
+            "fines.registry",
+            "fines.base"
         ]
     },
     {
@@ -5171,7 +5176,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.registry"
+            "fines.registry",
+            "fines.base"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -4817,7 +4817,8 @@
                                             "OTHER_GISGMP"
                                         ],
                                         "fillable_by": [
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base"
                                         ]
                                     }
                                 }
@@ -5200,7 +5201,8 @@
                                                     "30696/21/63004-ИП от 13.10.2021"
                                                 ],
                                                 "fillable_by": [
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base"
                                                 ]
                                             },
                                             "contact": {
@@ -5213,7 +5215,8 @@
                                                     "БИЦАДЗЕ О. А., тел: +7(84673)2-12-65//ОСП Большеглушицкого района (код отдела: 63004)"
                                                 ],
                                                 "fillable_by": [
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base"
                                                 ]
                                             }
                                         }
@@ -5234,7 +5237,8 @@
                                             "Иванов Иван Иванович"
                                         ],
                                         "fillable_by": [
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base"
                                         ]
                                     },
                                     "identifier": {
@@ -5251,7 +5255,8 @@
                                                     "STS"
                                                 ],
                                                 "fillable_by": [
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base"
                                                 ]
                                             },
                                             "number": {
@@ -5264,7 +5269,8 @@
                                                     "1111111111"
                                                 ],
                                                 "fillable_by": [
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base"
                                                 ]
                                             }
                                         }


### PR DESCRIPTION
## Description

### Changed

- Field with path `fines.items[].vendor.type` also fillable by `fines.base`
- Field with path `fines.items[].payer.name` also fillable by `fines.base`
- Field with path `fines.items[].payer.identifier.type` also fillable by `fines.base`
- Field with path `fines.items[].payer.identifier.number` also fillable by `fines.base`
- Field with path `fines.items[].fssp.enforcement_proceeding.number` also fillable by `fines.base`
- Field with path `fines.items[].fssp.enforcement_proceeding.contact` also fillable by `fines.base`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
