### PR TITLE
Add insurance.registry source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Source `insurance.registry`
+- Field with path `accidents.insurance.items[].date.event` also fillable by `insurance.registry`
+- Field with path `accidents.insurance.items[].policy.series` also fillable by `insurance.registry`
+- Field with path `accidents.insurance.items[].policy.number` also fillable by `insurance.registry`
+- Field with path `accidents.insurance.items[].insurer.name` also fillable by `insurance.registry`
+- Field with path `accidents.insurance.items[].actuality.date` also fillable by `insurance.registry`
+- Field with path `accidents.insurance.date.update` also fillable by `insurance.registry`
+
 ## v3.131.0
 
 ### Changed
@@ -11,6 +23,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Vehicle marks and models specs
 
 ## v3.130.0
+
+### Added
 
 - Source `leasing.registry`
 - Field with path `leasings.items[].contract_info.number`

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -3426,7 +3426,8 @@
         ],
         "fillable_by": [
             "insurance.dtp",
-            "insurance.dtp.basalt"
+            "insurance.dtp.basalt",
+            "insurance.registry"
         ]
     },
     {
@@ -3437,7 +3438,8 @@
         ],
         "fillable_by": [
             "insurance.dtp",
-            "insurance.dtp.basalt"
+            "insurance.dtp.basalt",
+            "insurance.registry"
         ]
     },
     {
@@ -3448,7 +3450,8 @@
         ],
         "fillable_by": [
             "insurance.dtp",
-            "insurance.dtp.basalt"
+            "insurance.dtp.basalt",
+            "insurance.registry"
         ]
     },
     {
@@ -3459,7 +3462,8 @@
         ],
         "fillable_by": [
             "insurance.dtp",
-            "insurance.dtp.basalt"
+            "insurance.dtp.basalt",
+            "insurance.registry"
         ]
     },
     {
@@ -3470,7 +3474,8 @@
         ],
         "fillable_by": [
             "insurance.dtp",
-            "insurance.dtp.basalt"
+            "insurance.dtp.basalt",
+            "insurance.registry"
         ]
     },
     {
@@ -3481,7 +3486,8 @@
         ],
         "fillable_by": [
             "insurance.dtp",
-            "insurance.dtp.basalt"
+            "insurance.dtp.basalt",
+            "insurance.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -9512,7 +9512,8 @@
                                     ],
                                     "fillable_by": [
                                         "insurance.dtp",
-                                        "insurance.dtp.basalt"
+                                        "insurance.dtp.basalt",
+                                        "insurance.registry"
                                     ]
                                 }
                             }
@@ -9542,7 +9543,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "insurance.dtp",
-                                                    "insurance.dtp.basalt"
+                                                    "insurance.dtp.basalt",
+                                                    "insurance.registry"
                                                 ]
                                             }
                                         }
@@ -9562,7 +9564,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "insurance.dtp",
-                                                    "insurance.dtp.basalt"
+                                                    "insurance.dtp.basalt",
+                                                    "insurance.registry"
                                                 ]
                                             }
                                         }
@@ -9582,7 +9585,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "insurance.dtp",
-                                                    "insurance.dtp.basalt"
+                                                    "insurance.dtp.basalt",
+                                                    "insurance.registry"
                                                 ]
                                             },
                                             "number": {
@@ -9596,7 +9600,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "insurance.dtp",
-                                                    "insurance.dtp.basalt"
+                                                    "insurance.dtp.basalt",
+                                                    "insurance.registry"
                                                 ]
                                             }
                                         }
@@ -9620,7 +9625,8 @@
                                                 ],
                                                 "fillable_by": [
                                                     "insurance.dtp",
-                                                    "insurance.dtp.basalt"
+                                                    "insurance.dtp.basalt",
+                                                    "insurance.registry"
                                                 ]
                                             }
                                         }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -318,5 +318,10 @@
         "name": "leasing.registry",
         "description": "Реестр лизингов",
         "enabled": true
+    },
+    {
+        "name": "insurance.registry",
+        "description": "Реестр европротоколов",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
## Description

### Added

- Source `insurance.registry`
- Field with path `accidents.insurance.items[].date.event` also fillable by `insurance.registry`
- Field with path `accidents.insurance.items[].policy.series` also fillable by `insurance.registry`
- Field with path `accidents.insurance.items[].policy.number` also fillable by `insurance.registry`
- Field with path `accidents.insurance.items[].insurer.name` also fillable by `insurance.registry`
- Field with path `accidents.insurance.items[].actuality.date` also fillable by `insurance.registry`
- Field with path `accidents.insurance.date.update` also fillable by `insurance.registry`