### PR TITLE
Draft: Add insurance.vehicle.registry source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Source `insurance.vehicle.registry`
+- Field with path `accidents.insurance.items[].date.event` also fillable by `insurance.vehicle.registry`
+- Field with path `accidents.insurance.items[].policy.series` also fillable by `insurance.vehicle.registry`
+- Field with path `accidents.insurance.items[].policy.number` also fillable by `insurance.vehicle.registry`
+- Field with path `accidents.insurance.items[].insurer.name` also fillable by `insurance.vehicle.registry`
+- Field with path `accidents.insurance.items[].actuality.date` also fillable by `insurance.vehicle.registry`
+- Field with path `accidents.insurance.date.update` also fillable by `insurance.vehicle.registry`
+
 ## v3.133.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -3427,7 +3427,8 @@
         "fillable_by": [
             "insurance.dtp",
             "insurance.dtp.basalt",
-            "insurance.registry"
+            "insurance.registry",
+            "insurance.vehicle.registry"
         ]
     },
     {
@@ -3439,7 +3440,8 @@
         "fillable_by": [
             "insurance.dtp",
             "insurance.dtp.basalt",
-            "insurance.registry"
+            "insurance.registry",
+            "insurance.vehicle.registry"
         ]
     },
     {
@@ -3451,7 +3453,8 @@
         "fillable_by": [
             "insurance.dtp",
             "insurance.dtp.basalt",
-            "insurance.registry"
+            "insurance.registry",
+            "insurance.vehicle.registry"
         ]
     },
     {
@@ -3463,7 +3466,8 @@
         "fillable_by": [
             "insurance.dtp",
             "insurance.dtp.basalt",
-            "insurance.registry"
+            "insurance.registry",
+            "insurance.vehicle.registry"
         ]
     },
     {
@@ -3475,7 +3479,8 @@
         "fillable_by": [
             "insurance.dtp",
             "insurance.dtp.basalt",
-            "insurance.registry"
+            "insurance.registry",
+            "insurance.vehicle.registry"
         ]
     },
     {
@@ -3487,7 +3492,8 @@
         "fillable_by": [
             "insurance.dtp",
             "insurance.dtp.basalt",
-            "insurance.registry"
+            "insurance.registry",
+            "insurance.vehicle.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -9513,7 +9513,8 @@
                                     "fillable_by": [
                                         "insurance.dtp",
                                         "insurance.dtp.basalt",
-                                        "insurance.registry"
+                                        "insurance.registry",
+                                        "insurance.vehicle.registry"
                                     ]
                                 }
                             }
@@ -9544,7 +9545,8 @@
                                                 "fillable_by": [
                                                     "insurance.dtp",
                                                     "insurance.dtp.basalt",
-                                                    "insurance.registry"
+                                                    "insurance.registry",
+                                                    "insurance.vehicle.registry"
                                                 ]
                                             }
                                         }
@@ -9565,7 +9567,8 @@
                                                 "fillable_by": [
                                                     "insurance.dtp",
                                                     "insurance.dtp.basalt",
-                                                    "insurance.registry"
+                                                    "insurance.registry",
+                                                    "insurance.vehicle.registry"
                                                 ]
                                             }
                                         }
@@ -9586,7 +9589,8 @@
                                                 "fillable_by": [
                                                     "insurance.dtp",
                                                     "insurance.dtp.basalt",
-                                                    "insurance.registry"
+                                                    "insurance.registry",
+                                                    "insurance.vehicle.registry"
                                                 ]
                                             },
                                             "number": {
@@ -9601,7 +9605,8 @@
                                                 "fillable_by": [
                                                     "insurance.dtp",
                                                     "insurance.dtp.basalt",
-                                                    "insurance.registry"
+                                                    "insurance.registry",
+                                                    "insurance.vehicle.registry"
                                                 ]
                                             }
                                         }
@@ -9626,7 +9631,8 @@
                                                 "fillable_by": [
                                                     "insurance.dtp",
                                                     "insurance.dtp.basalt",
-                                                    "insurance.registry"
+                                                    "insurance.registry",
+                                                    "insurance.vehicle.registry"
                                                 ]
                                             }
                                         }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -328,5 +328,10 @@
         "name": "fssp.base.executive",
         "description": "Данные об исполнительных производствах в базе ФССП",
         "enabled": true
+    },
+    {
+        "name": "insurance.vehicle.registry",
+        "description": "Реестр европротоколов по ТС",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
## Description

### Added

- Source `insurance.vehicle.registry`
- Field with path `accidents.insurance.items[].date.event` also fillable by `insurance.vehicle.registry`
- Field with path `accidents.insurance.items[].policy.series` also fillable by `insurance.vehicle.registry`
- Field with path `accidents.insurance.items[].policy.number` also fillable by `insurance.vehicle.registry`
- Field with path `accidents.insurance.items[].insurer.name` also fillable by `insurance.vehicle.registry`
- Field with path `accidents.insurance.items[].actuality.date` also fillable by `insurance.vehicle.registry`
- Field with path `accidents.insurance.date.update` also fillable by `insurance.vehicle.registry`
