### PR TITLE
Add owner.taxi.history source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Source `owner.taxi.history`
+- Field with path `additional_info.vehicle.owner.taxi_history.probable_taxi_driver`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.actuality.date`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.reg_num`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.brand_name_original`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.model_name_original`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].full_number`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].number`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].issued`
+- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].region.code`
+- Field with path `additional_info.vehicle.owner.taxi_history.probable_use.items[].reg_num`
+- Field with path `additional_info.vehicle.owner.taxi_history.probable_use.items[].date`
+
 ## v3.140.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -948,6 +948,116 @@
         ]
     },
     {
+        "path": "additional_info.vehicle.owner.taxi_history.probable_taxi_driver",
+        "description": "История владельца в такси: Возможная работа в такси",
+        "types": [
+            "boolean"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.actuality.date",
+        "description": "История владельца в такси: Дата актуальности данных",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.reg_num",
+        "description": "История владельца в такси: Государственный регистрационный знак",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.brand_name_original",
+        "description": "История владельца в такси: Марка автомобиля",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.model_name_original",
+        "description": "История владельца в такси: Модель автомобиля",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].full_number",
+        "description": "История владельца в такси: Регистрационный номер разрешения",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].number",
+        "description": "История владельца в такси: Регистрационный номер разрешения",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].issued",
+        "description": "История владельца в такси: Дата выдачи разрешения",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].region.code",
+        "description": "История владельца в такси: Код региона выдачи лицензии",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.probable_use.items[].reg_num",
+        "description": "История владельца в такси: Вероятный государственный регистрационный знак",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.owner.taxi_history.probable_use.items[].date",
+        "description": "История владельца в такси: Вероятная дата",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "owner.taxi.history"
+        ]
+    },
+    {
         "path": "additional_info.vehicle.sts.date.receive",
         "description": "Дополнительная информация: Дата выдачи СТС",
         "types": [

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -158,6 +158,37 @@
                     "street": null,
                     "house": null,
                     "postal_code": null
+                },
+                "taxi_history": {
+                    "probable_taxi_driver": null,
+                    "taxi_licenses": {
+                        "items": [
+                            {
+                                "vehicle": {
+                                    "reg_num": null,
+                                    "brand_name_original": null,
+                                    "model_name_original": null
+                                },
+                                "full_number": null,
+                                "number": null,
+                                "issued": null,
+                                "region": {
+                                    "code": null
+                                }
+                            }
+                        ],
+                        "actuality": {
+                            "date": null
+                        }
+                    },
+                    "probable_use": {
+                        "items": [
+                            {
+                                "reg_num": null,
+                                "date": null
+                            }
+                        ]
+                    }
                 }
             },
             "passport": {

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -158,6 +158,37 @@
                     "street": null,
                     "house": null,
                     "postal_code": "141207"
+                },
+                "taxi_history": {
+                    "probable_taxi_driver": true,
+                    "taxi_licenses": {
+                        "items": [
+                            {
+                                "vehicle": {
+                                    "reg_num": "A111AA196",
+                                    "brand_name_original": "Hyundai",
+                                    "model_name_original": "Sonata"
+                                },
+                                "full_number": "91480",
+                                "number": "91480",
+                                "issued": "2022-05-25 00:00:00",
+                                "region": {
+                                    "code": "23"
+                                }
+                            }
+                        ],
+                        "actuality": {
+                            "date": "2023-11-02 00:00:00"
+                        }
+                    },
+                    "probable_use": {
+                        "items": [
+                            {
+                                "reg_num": "О196АМ196",
+                                "date": "2020-08-11 00:00:00"
+                            }
+                        ]
+                    }
                 }
             },
             "passport": {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -1948,6 +1948,215 @@
                                         "base.alt",
                                         "regactions.registry"
                                     ]
+                                },
+                                "taxi_history": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "probable_taxi_driver": {
+                                            "description": "Возможная работа в такси",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ],
+                                            "examples": [
+                                                false
+                                            ],
+                                            "fillable_by": [
+                                                "owner.taxi.history"
+                                            ]
+                                        },
+                                        "taxi_licenses": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "actuality": {
+                                                    "type": "object",
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                        "date": {
+                                                            "description": "Дата актуальности данных",
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "null"
+                                                                },
+                                                                {
+                                                                    "$ref": "#/definitions/datetime"
+                                                                }
+                                                            ],
+                                                            "examples": [
+                                                                "2018-08-05 00:00:00"
+                                                            ],
+                                                            "fillable_by": [
+                                                                "owner.taxi.history"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "vehicle": {
+                                                                "type": "object",
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "reg_num": {
+                                                                        "description": "Государственный регистрационный знак",
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ],
+                                                                        "examples": [
+                                                                            "A111AA196"
+                                                                        ],
+                                                                        "fillable_by": [
+                                                                            "owner.taxi.history"
+                                                                        ]
+                                                                    },
+                                                                    "brand_name_original": {
+                                                                        "description": "Марка автомобиля",
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ],
+                                                                        "examples": [
+                                                                            "Hyundai"
+                                                                        ],
+                                                                        "fillable_by": [
+                                                                            "owner.taxi.history"
+                                                                        ]
+                                                                    },
+                                                                    "model_name_original": {
+                                                                        "description": "Модель автомобиля",
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ],
+                                                                        "examples": [
+                                                                            "Sonata"
+                                                                        ],
+                                                                        "fillable_by": [
+                                                                            "owner.taxi.history"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "full_number": {
+                                                                "description": "Регистрационный номер разрешения",
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ],
+                                                                "examples": [
+                                                                    "91480"
+                                                                ],
+                                                                "fillable_by": [
+                                                                    "owner.taxi.history"
+                                                                ]
+                                                            },
+                                                            "number": {
+                                                                "description": "Регистрационный номер разрешения",
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ],
+                                                                "examples": [
+                                                                    "91480"
+                                                                ],
+                                                                "fillable_by": [
+                                                                    "owner.taxi.history"
+                                                                ]
+                                                            },
+                                                            "issued": {
+                                                                "description": "Дата выдачи разрешения",
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "null"
+                                                                    },
+                                                                    {
+                                                                        "$ref": "#/definitions/datetime"
+                                                                    }
+                                                                ],
+                                                                "examples": [
+                                                                    "2018-08-05 00:00:00"
+                                                                ],
+                                                                "fillable_by": [
+                                                                    "owner.taxi.history"
+                                                                ]
+                                                            },
+                                                            "region": {
+                                                                "type": "object",
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "code": {
+                                                                        "description": "Код региона выдачи лицензии",
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ],
+                                                                        "examples": [
+                                                                            "23"
+                                                                        ],
+                                                                        "fillable_by": [
+                                                                            "owner.taxi.history"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "probable_use": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "reg_num": {
+                                                                "description": "Вероятный государственный регистрационный зна",
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ],
+                                                                "examples": [
+                                                                    "A111AA196"
+                                                                ],
+                                                                "fillable_by": [
+                                                                    "owner.taxi.history"
+                                                                ]
+                                                            },
+                                                            "date": {
+                                                                "description": "Вероятная дата",
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "null"
+                                                                    },
+                                                                    {
+                                                                        "$ref": "#/definitions/datetime"
+                                                                    }
+                                                                ],
+                                                                "examples": [
+                                                                    "2018-08-05 00:00:00"
+                                                                ],
+                                                                "fillable_by": [
+                                                                    "owner.taxi.history"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -338,5 +338,10 @@
         "name": "customs.fts",
         "description": "Данные о таможенном оформлении в базе ФТС",
         "enabled": true
+    },
+    {
+        "name": "owner.taxi.history",
+        "description": "История такси владельца ТС",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
## Description

### Added

- Source `owner.taxi.history`
- Field with path `additional_info.vehicle.owner.taxi_history.probable_taxi_driver`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.actuality.date`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.reg_num`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.brand_name_original`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.model_name_original`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].full_number`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].number`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].issued`
- Field with path `additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].region.code`
- Field with path `additional_info.vehicle.owner.taxi_history.probable_use.items[].reg_num`
- Field with path `additional_info.vehicle.owner.taxi_history.probable_use.items[].date`
