### PR TITLE
Add new customs.base fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Field with path `customs.history.items[].country.to.code`
 - Field with path `customs.history.items[].sender.name`
 - Field with path `customs.history.items[].sender.tin`
-- Field with path `customs.history.items[].direction.type`
+- Field with path `customs.history.items[].operation.type`
 - Field with path `customs.history.items[].country.original.name`
 - Field with path `customs.history.items[].country.original.code`
 - Field with path `customs.history.items[].manufacturer.name`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Field with path `customs.history.items[].owner.tin`
+- Field with path `customs.history.items[].country.from.code`
+- Field with path `customs.history.items[].country.to.code`
+- Field with path `customs.history.items[].sender.name`
+- Field with path `customs.history.items[].sender.tin`
+- Field with path `customs.history.items[].direction.type`
+- Field with path `customs.history.items[].country.original.name`
+- Field with path `customs.history.items[].country.original.code`
+- Field with path `customs.history.items[].manufacturer.name`
+
+### Changed
+
+- Field with path `identifiers.vehicle.vin` also fillable by `customs.base`
+- Field with path `identifiers.vehicle.body` also fillable by `customs.base`
+- Field with path `identifiers.vehicle.chassis` also fillable by `customs.base`
+- Field with path `identifiers_masked.vehicle.vin` also fillable by `customs.base`
+- Field with path `identifiers_masked.vehicle.body` also fillable by `customs.base`
+- Field with path `identifiers_masked.vehicle.chassis` also fillable by `customs.base`
+- Field with path `tech_data.brand.name.original` also fillable by `customs.base`
+- Field with path `tech_data.model.name.original` also fillable by `customs.base`
+- Field with path `tech_data.engine.fuel.type` also fillable by `customs.base`
+- Field with path `tech_data.engine.fuel.type_id` also fillable by `customs.base`
+- Field with path `tech_data.engine.number` also fillable by `customs.base`
+- Field with path `tech_data.engine.model.name` also fillable by `customs.base`
+- Field with path `tech_data.engine.volume` also fillable by `customs.base`
+- Field with path `tech_data.engine.power.hp` also fillable by `customs.base`
+- Field with path `tech_data.engine.power.kw` also fillable by `customs.base`
+- Field with path `tech_data.engine.standarts.emission.euro` also fillable by `customs.base`
+- Field with path `tech_data.weight.netto` also fillable by `customs.base`
+- Field with path `tech_data.weight.max` also fillable by `customs.base`
+- Field with path `tech_data.body.color.type` also fillable by `customs.base`
+- Field with path `tech_data.drive.type` also fillable by `customs.base`
+- Field with path `tech_data.drive.type_id` also fillable by `customs.base`
+
 ## v3.143.0
 
 ### Changed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -18,7 +18,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -85,7 +86,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -105,7 +107,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -139,7 +142,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -206,7 +210,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -226,7 +231,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -269,7 +275,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "gibdd.history.registry",
-            "customs.fts"
+            "customs.fts",
+            "customs.base"
         ]
     },
     {
@@ -321,7 +328,8 @@
             "gibdd.eaisto",
             "gibdd.diagnostic.cards",
             "base.basalt",
-            "eaisto.registry"
+            "eaisto.registry",
+            "customs.base"
         ]
     },
     {
@@ -415,7 +423,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.alt"
+            "base.alt",
+            "customs.base"
         ]
     },
     {
@@ -461,7 +470,8 @@
             "base.alt",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -477,7 +487,8 @@
             "base.basalt",
             "customs.base",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -492,7 +503,8 @@
             "base.alt",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -506,7 +518,8 @@
             "base.ext",
             "base.basalt",
             "base.alt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -522,7 +535,8 @@
             "base.basalt",
             "base.alt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -540,7 +554,8 @@
             "regactions.registry",
             "base.registry",
             "base.registry.retry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -557,7 +572,8 @@
             "base.basalt",
             "base.registry",
             "base.registry.retry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -571,7 +587,8 @@
             "base.ext",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -586,7 +603,8 @@
             "gibdd.eaisto",
             "base.basalt",
             "base.alt",
-            "regactions.registry"
+            "regactions.registry",
+            "customs.base"
         ]
     },
     {
@@ -603,7 +621,8 @@
             "base.basalt",
             "regactions.registry",
             "base.registry",
-            "base.registry.retry"
+            "base.registry.retry",
+            "customs.base"
         ]
     },
     {
@@ -643,7 +662,8 @@
             "base.ext",
             "base.alt",
             "base.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -657,7 +677,8 @@
             "base.ext",
             "base.alt",
             "base.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "customs.base"
         ]
     },
     {
@@ -4514,6 +4535,16 @@
         ]
     },
     {
+        "path": "customs.history.items[].owner.tin",
+        "description": "История по таможне: ИНН владельца ТС",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
         "path": "customs.history.items[].country.from.name",
         "description": "История по таможне: Наименование страны экспортера",
         "types": [
@@ -4526,8 +4557,28 @@
         ]
     },
     {
+        "path": "customs.history.items[].country.from.code",
+        "description": "История по таможне: Код страны экспортера",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
         "path": "customs.history.items[].country.to.name",
         "description": "История по таможне: Наименование страны импортера",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
+        "path": "customs.history.items[].country.to.code",
+        "description": "История по таможне: Код страны импортера",
         "types": [
             "string"
         ],
@@ -4543,6 +4594,66 @@
         ],
         "fillable_by": [
             "base.basalt"
+        ]
+    },
+    {
+        "path": "customs.history.items[].sender.name",
+        "description": "История по таможне: Наименование отправителя",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
+        "path": "customs.history.items[].sender.tin",
+        "description": "История по таможне: ИНН отправителя",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
+        "path": "customs.history.items[].direction.type",
+        "description": "История по таможне: Тип таможенной операции",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
+        "path": "customs.history.items[].country.original.name",
+        "description": "История по таможне: Наименование страны происхождения",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
+        "path": "customs.history.items[].country.original.code",
+        "description": "История по таможне: Код страны происхождения",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
+        ]
+    },
+    {
+        "path": "customs.history.items[].manufacturer.name",
+        "description": "История по таможне: Наименование производителя",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "customs.base"
         ]
     },
     {

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -4617,7 +4617,7 @@
         ]
     },
     {
-        "path": "customs.history.items[].direction.type",
+        "path": "customs.history.items[].operation.type",
         "description": "История по таможне: Тип таможенной операции",
         "types": [
             "string"

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -765,18 +765,35 @@
                     },
                     "owner": {
                         "type": null,
-                        "value": null
+                        "value": null,
+                        "tin": null
                     },
                     "country": {
                         "from": {
-                            "name": null
+                            "name": null,
+                            "code": null
                         },
                         "to": {
-                            "name": null
+                            "name": null,
+                            "code": null
+                        },
+                        "original": {
+                            "name": null,
+                            "code": null
                         }
                     },
                     "utilization_tax": {
                         "status": null
+                    },
+                    "sender": {
+                        "name": null,
+                        "tin": null
+                    },
+                    "direction": {
+                        "type": null
+                    },
+                    "manufacturer": {
+                        "name": null
                     }
                 }
             ],

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -789,7 +789,7 @@
                         "name": null,
                         "tin": null
                     },
-                    "direction": {
+                    "operation": {
                         "type": null
                     },
                     "manufacturer": {

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -1014,7 +1014,7 @@
                         "name": "ООО Автоторг",
                         "tin": "1363519988"
                     },
-                    "direction": {
+                    "operation": {
                         "type": "IMPORT"
                     },
                     "manufacturer": {

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -990,18 +990,35 @@
                     },
                     "owner": {
                         "type": "LEGAL",
-                        "value": "ЗАО ВекторРечПив"
+                        "value": "ЗАО ВекторРечПив",
+                        "tin": "1363519987"
                     },
                     "country": {
                         "from": {
-                            "name": "Тайланд"
+                            "name": "Бразилия",
+                            "code": " BR"
                         },
                         "to": {
-                            "name": "RU"
+                            "name": "Россия",
+                            "code": "RU"
+                        },
+                        "original": {
+                            "name": "Румыния",
+                            "code": "RO"
                         }
                     },
                     "utilization_tax": {
                         "status": "Уплачен"
+                    },
+                    "sender": {
+                        "name": "ООО Автоторг",
+                        "tin": "1363519988"
+                    },
+                    "direction": {
+                        "type": "IMPORT"
+                    },
+                    "manufacturer": {
+                        "name": "AUDI AG"
                     }
                 }
             ],

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -359,7 +359,8 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "reg_num": {
@@ -466,7 +467,8 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "chassis": {
@@ -496,7 +498,8 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         }
                     }
@@ -564,7 +567,8 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "reg_num": {
@@ -659,7 +663,8 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "chassis": {
@@ -686,7 +691,8 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         }
                     }
@@ -765,7 +771,8 @@
                                         "eaisto.registry",
                                         "base.registry.retry",
                                         "gibdd.history.registry",
-                                        "customs.fts"
+                                        "customs.fts",
+                                        "customs.base"
                                     ]
                                 },
                                 "rus": {
@@ -854,7 +861,8 @@
                                         "gibdd.eaisto",
                                         "base.basalt",
                                         "eaisto.registry",
-                                        "gibdd.diagnostic.cards"
+                                        "gibdd.diagnostic.cards",
+                                        "customs.base"
                                     ]
                                 },
                                 "normalized": {
@@ -996,7 +1004,8 @@
                                     "fillable_by": [
                                         "base",
                                         "base.ext",
-                                        "base.alt"
+                                        "base.alt",
+                                        "customs.base"
                                     ]
                                 }
                             }
@@ -1078,7 +1087,8 @@
                                         "base.alt",
                                         "base.basalt",
                                         "regactions.registry",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "customs.base"
                                     ]
                                 },
                                 "type_id": {
@@ -1101,7 +1111,8 @@
                                         "base.basalt",
                                         "customs.base",
                                         "regactions.registry",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "customs.base"
                                     ]
                                 }
                             }
@@ -1127,7 +1138,8 @@
                                 "base.alt",
                                 "base.basalt",
                                 "regactions.registry",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "model": {
@@ -1148,7 +1160,8 @@
                                         "base.ext",
                                         "base.alt",
                                         "base.basalt",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "customs.base"
                                     ]
                                 }
                             }
@@ -1170,7 +1183,8 @@
                                 "base.alt",
                                 "base.basalt",
                                 "regactions.registry",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "power": {
@@ -1196,7 +1210,8 @@
                                         "regactions.registry",
                                         "base.registry",
                                         "base.registry.retry",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "customs.base"
                                     ]
                                 },
                                 "kw": {
@@ -1217,7 +1232,8 @@
                                         "base.basalt",
                                         "base.registry",
                                         "base.registry.retry",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "customs.base"
                                     ]
                                 }
                             }
@@ -1244,7 +1260,8 @@
                                                 "base.ext",
                                                 "base.basalt",
                                                 "regactions.registry",
-                                                "gibdd.history.registry"
+                                                "gibdd.history.registry",
+                                                "customs.base"
                                             ]
                                         }
                                     }
@@ -1273,7 +1290,8 @@
                                 "gibdd.eaisto",
                                 "base.alt",
                                 "base.basalt",
-                                "regactions.registry"
+                                "regactions.registry",
+                                "customs.base"
                             ]
                         },
                         "max": {
@@ -1294,7 +1312,8 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "base.registry",
-                                "base.registry.retry"
+                                "base.registry.retry",
+                                "customs.base"
                             ]
                         }
                     }
@@ -1370,7 +1389,8 @@
                                 "base.ext",
                                 "base.alt",
                                 "base.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         },
                         "type_id": {
@@ -1391,7 +1411,8 @@
                                 "base.ext",
                                 "base.alt",
                                 "base.basalt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "customs.base"
                             ]
                         }
                     }
@@ -6373,6 +6394,19 @@
                                                 "fillable_by": [
                                                     "customs.base"
                                                 ]
+                                            },
+                                            "tin": {
+                                                "description": "ИНН владельца ТС",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "examples": [
+                                                    "1363519987"
+                                                ],
+                                                "fillable_by": [
+                                                    "customs.base"
+                                                ]
                                             }
                                         }
                                     },
@@ -6391,12 +6425,25 @@
                                                             "null"
                                                         ],
                                                         "examples": [
-                                                            "Тайланд"
+                                                            "Бразилия"
                                                         ],
                                                         "fillable_by": [
                                                             "customs.base",
                                                             "customs.fts",
                                                             "base.basalt"
+                                                        ]
+                                                    },
+                                                    "code": {
+                                                        "description": "Код страны экспортера",
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "examples": [
+                                                            "BR"
+                                                        ],
+                                                        "fillable_by": [
+                                                            "customs.base"
                                                         ]
                                                     }
                                                 }
@@ -6407,6 +6454,51 @@
                                                 "properties": {
                                                     "name": {
                                                         "description": "Наименование страны импортера",
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "examples": [
+                                                            "Россия"
+                                                        ],
+                                                        "fillable_by": [
+                                                            "customs.base"
+                                                        ]
+                                                    },
+                                                    "code": {
+                                                        "description": "Код страны импортера",
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "examples": [
+                                                            "RU"
+                                                        ],
+                                                        "fillable_by": [
+                                                            "customs.base"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "original": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Наименование страны происхождения",
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "examples": [
+                                                            "Россия"
+                                                        ],
+                                                        "fillable_by": [
+                                                            "customs.base"
+                                                        ]
+                                                    },
+                                                    "code": {
+                                                        "description": "Код страны происхождения",
                                                         "type": [
                                                             "string",
                                                             "null"
@@ -6442,6 +6534,78 @@
                                                 ],
                                                 "fillable_by": [
                                                     "base.basalt"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "sender": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "description": "Наименование отправителя",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "examples": [
+                                                    "ООО Автоторг"
+                                                ],
+                                                "fillable_by": [
+                                                    "customs.base"
+                                                ]
+                                            },
+                                            "tin": {
+                                                "description": "ИНН отправителя",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "examples": [
+                                                    "1363519987"
+                                                ],
+                                                "fillable_by": [
+                                                    "customs.base"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "direction": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "type": {
+                                                "description": "Тип таможенной операции",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "examples": [
+                                                    "EXPORT",
+                                                    "IMPORT",
+                                                    "REEXPORT"
+                                                ],
+                                                "fillable_by": [
+                                                    "customs.base"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "manufacturer": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "description": "Наименование производителя",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "examples": [
+                                                    "AUDI AG"
+                                                ],
+                                                "fillable_by": [
+                                                    "customs.base"
                                                 ]
                                             }
                                         }

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -6570,7 +6570,7 @@
                                             }
                                         }
                                     },
-                                    "direction": {
+                                    "operation": {
                                         "type": "object",
                                         "additionalProperties": false,
                                         "properties": {


### PR DESCRIPTION
## Description

### Added

- Field with path `customs.history.items[].owner.tin`
- Field with path `customs.history.items[].country.from.code`
- Field with path `customs.history.items[].country.to.code`
- Field with path `customs.history.items[].sender.name`
- Field with path `customs.history.items[].sender.tin`
- Field with path `customs.history.items[].direction.type`
- Field with path `customs.history.items[].country.original.name`
- Field with path `customs.history.items[].country.original.code`
- Field with path `customs.history.items[].manufacturer.name`

### Changed

- Field with path `identifiers.vehicle.vin` also fillable by `customs.base`
- Field with path `identifiers.vehicle.body` also fillable by `customs.base`
- Field with path `identifiers.vehicle.chassis` also fillable by `customs.base`
- Field with path `identifiers_masked.vehicle.vin` also fillable by `customs.base`
- Field with path `identifiers_masked.vehicle.body` also fillable by `customs.base`
- Field with path `identifiers_masked.vehicle.chassis` also fillable by `customs.base`
- Field with path `tech_data.brand.name.original` also fillable by `customs.base`
- Field with path `tech_data.model.name.original` also fillable by `customs.base`
- Field with path `tech_data.engine.fuel.type` also fillable by `customs.base`
- Field with path `tech_data.engine.fuel.type_id` also fillable by `customs.base`
- Field with path `tech_data.engine.number` also fillable by `customs.base`
- Field with path `tech_data.engine.model.name` also fillable by `customs.base`
- Field with path `tech_data.engine.volume` also fillable by `customs.base`
- Field with path `tech_data.engine.power.hp` also fillable by `customs.base`
- Field with path `tech_data.engine.power.kw` also fillable by `customs.base`
- Field with path `tech_data.engine.standarts.emission.euro` also fillable by `customs.base`
- Field with path `tech_data.weight.netto` also fillable by `customs.base`
- Field with path `tech_data.weight.max` also fillable by `customs.base`
- Field with path `tech_data.body.color.type` also fillable by `customs.base`
- Field with path `tech_data.drive.type` also fillable by `customs.base`
- Field with path `tech_data.drive.type_id` also fillable by `customs.base`
Fixes # (issue)
