### PR TITLE
Draft: Add fines.items[].location.coordinates fillable by fines.registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Field with path `fines.items[].location.coordinates` also fillable by `fines.registry`
+
 ## v3.145.0
 
 ### Changed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -5586,7 +5586,8 @@
             "string"
         ],
         "fillable_by": [
-            "fines.base"
+            "fines.base",
+            "fines.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -5402,7 +5402,8 @@
                                             "56.900455,60.613899"
                                         ],
                                         "fillable_by": [
-                                            "fines.base"
+                                            "fines.base",
+                                            "fines.registry"
                                         ]
                                     }
                                 }


### PR DESCRIPTION
## Description

### Changed

- Field with path `fines.items[].location.coordinates` also fillable by `fines.registry`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file