### PR TITLE
Disable references.oats source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## Unreleased
 
-### Changed 
+### Changed
 
 - Disabled source with name `references.oats`
 - Field with path `additional_info.catalog.oats.*` not fillable by `references.oats` anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed 
 
 - Disabled source with name `references.oats`
-- Field with path `additional_info.catalog.oats.items[].code` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.brand.name` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.model.name` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.modification.name` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.engine.model.name` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.engine.type` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.engine.power.hp` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.engine.power.kw` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.engine.volume` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.category.name` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.manufactured.year.start` not fillable by `references.oats` anymore
-- Field with path `additional_info.catalog.oats.items[].vehicle.manufactured.year.end` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.*` not fillable by `references.oats` anymore
 
 ## v3.148.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed 
+
+- Disabled source with name `references.oats`
+- Field with path `additional_info.catalog.oats.items[].code` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.brand.name` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.model.name` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.modification.name` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.engine.model.name` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.engine.type` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.engine.power.hp` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.engine.power.kw` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.engine.volume` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.category.name` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.manufactured.year.start` not fillable by `references.oats` anymore
+- Field with path `additional_info.catalog.oats.items[].vehicle.manufactured.year.end` not fillable by `references.oats` anymore
+
 ## v3.148.0
 
 ### Added

--- a/__tests__/sources/sources_list.test.ts
+++ b/__tests__/sources/sources_list.test.ts
@@ -11,7 +11,8 @@ const disabled_sources: {[k: string]: string[]} = {
         "ramiosago.base",
         "references.transdekra",
         "rsaosago.base.ext",
-        "gibdd.diagnostic.cards"
+        "gibdd.diagnostic.cards",
+        'references.oats'
     ]
 };
 // for each group of specifications...

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -1413,9 +1413,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.brand.name",
@@ -1423,9 +1421,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.model.name",
@@ -1433,9 +1429,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.modification.name",
@@ -1443,9 +1437,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.engine.model.name",
@@ -1453,9 +1445,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.engine.type",
@@ -1463,9 +1453,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.engine.power.hp",
@@ -1473,9 +1461,7 @@
         "types": [
             "float"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.engine.power.kw",
@@ -1483,9 +1469,7 @@
         "types": [
             "float"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.engine.volume",
@@ -1493,9 +1477,7 @@
         "types": [
             "float"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.category.name",
@@ -1503,9 +1485,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.manufactured.year.start",
@@ -1513,9 +1493,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.oats.items[].vehicle.manufactured.year.end",
@@ -1523,9 +1501,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-            "references.oats"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.tecdoc.items[].manufacturer_id",
@@ -1533,8 +1509,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.tecdoc.items[].model_id",
@@ -1542,8 +1517,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.tecdoc.items[].id",
@@ -1551,8 +1525,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.tecdoc.items[].name",
@@ -1560,8 +1533,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.catalog.tecdoc.items[].description",
@@ -1569,8 +1541,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.identifiers.vin.checksum_validated",
@@ -1578,8 +1549,7 @@
         "types": [
             "boolean"
         ],
-        "fillable_by": [
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.modifications.was_modificated",

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -2983,9 +2983,7 @@
                                                 "examples": [
                                                     "366013880"
                                                 ],
-                                                "fillable_by": [
-                                                    "references.oats"
-                                                ]
+                                                "fillable_by": []
                                             },
                                             "vehicle": {
                                                 "type": "object",
@@ -3004,9 +3002,7 @@
                                                                 "examples": [
                                                                     "Skoda"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "references.oats"
-                                                                ]
+                                                                "fillable_by": []
                                                             }
                                                         }
                                                     },
@@ -3023,9 +3019,7 @@
                                                                 "examples": [
                                                                     "Octavia III"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "references.oats"
-                                                                ]
+                                                                "fillable_by": []
                                                             }
                                                         }
                                                     },
@@ -3042,9 +3036,7 @@
                                                                 "examples": [
                                                                     "1.8TSI Elegance"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "references.oats"
-                                                                ]
+                                                                "fillable_by": []
                                                             }
                                                         }
                                                     },
@@ -3065,9 +3057,7 @@
                                                                         "examples": [
                                                                             "G4ED"
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "references.oats"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     }
                                                                 }
                                                             },
@@ -3084,9 +3074,7 @@
                                                                 "examples": [
                                                                     "Бензиновый"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "references.oats"
-                                                                ]
+                                                                "fillable_by": []
                                                             },
                                                             "power": {
                                                                 "type": "object",
@@ -3100,9 +3088,7 @@
                                                                         "examples": [
                                                                             104.0
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "references.oats"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     },
                                                                     "kw": {
                                                                         "description": "Мощность двигателя ТС (кВ)",
@@ -3113,9 +3099,7 @@
                                                                         "examples": [
                                                                             77.0
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "references.oats"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     }
                                                                 }
                                                             },
@@ -3128,9 +3112,7 @@
                                                                 "examples": [
                                                                     1800.0
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "references.oats"
-                                                                ]
+                                                                "fillable_by": []
                                                             }
                                                         }
                                                     },
@@ -3147,9 +3129,7 @@
                                                                 "examples": [
                                                                     "Passenger"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "references.oats"
-                                                                ]
+                                                                "fillable_by": []
                                                             }
                                                         }
                                                     },
@@ -3169,9 +3149,7 @@
                                                                         "examples": [
                                                                             2014
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "references.oats"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     },
                                                                     "end": {
                                                                         "description": "Год окончания производства ТС",
@@ -3182,9 +3160,7 @@
                                                                         "examples": [
                                                                             2015
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "references.oats"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     }
                                                                 }
                                                             }
@@ -3216,8 +3192,7 @@
                                     "examples": [
                                         true
                                     ],
-                                    "fillable_by": [
-                                    ]
+                                    "fillable_by": []
                                 }
                             }
                         }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -92,7 +92,7 @@
     {
         "name": "references.oats",
         "description": "Справочник ТС ОАТС",
-        "enabled": true
+        "enabled": false
     },
     {
         "name": "pledge.house",


### PR DESCRIPTION
## Description

### Changed 

- Disabled source with name `references.oats`
- Field with path `additional_info.catalog.oats.*` not fillable by `references.oats` anymore