### PR TITLE
Draft: Add elpts.online source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Field with path `additional_info.vehicle.passport.type`
+- Field with path `additional_info.vehicle.passport.status`
+- Field with path `additional_info.vehicle.car_scrappage_fees`
+- Field with path `additional_info.vehicle.custom_registration`
+- Field with path `additional_info.vehicle.restriction.customs`
+- Field with path `additional_info.vehicle.restriction.other`
+
+### Changed
+
+- Field with path `identifiers.vehicle.pts` also fillable by `elpts.online`
+- Field with path `identifiers_masked.vehicle.pts` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.passport.number` also fillable by `elpts.online`
+
 ## v3.149.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Field with path `additional_info.vehicle.passport.type`
 - Field with path `additional_info.vehicle.passport.status`
-- Field with path `additional_info.vehicle.car_scrappage_fees`
-- Field with path `additional_info.vehicle.custom_registration`
+- Field with path `additional_info.vehicle.utilization_tax`
+- Field with path `additional_info.vehicle.customs_registration`
 - Field with path `additional_info.vehicle.restriction.customs`
 - Field with path `additional_info.vehicle.restriction.other`
 

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -65,7 +65,8 @@
             "gibdd.history",
             "base.basalt",
             "base.alt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "elpts.online"
         ]
     },
     {
@@ -189,7 +190,8 @@
             "gibdd.history",
             "base.basalt",
             "base.alt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "elpts.online"
         ]
     },
     {
@@ -1123,7 +1125,28 @@
             "base.basalt",
             "base.ext",
             "base.alt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "elpts.online"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.passport.type",
+        "description": "Дополнительная информация: Вид электронного паспорта",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "elpts.online"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.passport.status",
+        "description": "Дополнительная информация: Статус электронного паспорта",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "elpts.online"
         ]
     },
     {
@@ -1591,6 +1614,46 @@
         "fillable_by": [
             "base",
             "base.ext"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.car_scrappage_fees",
+        "description": "Дополнительная информация: Сведения об уплате утилизационного сбора",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "elpts.online"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.custom_registration",
+        "description": "Дополнительная информация: Сведения о выпуске (таможенное оформление)",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "elpts.online"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.restriction.customs",
+        "description": "Дополнительная информация: Таможенные ограничения",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "elpts.online"
+        ]
+    },
+    {
+        "path": "additional_info.vehicle.restriction.other",
+        "description": "Дополнительная информация: Ограничения (обременения) за исключением таможенных",
+        "types": [
+            "string"
+        ],
+        "fillable_by": [
+            "elpts.online"
         ]
     },
     {

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -1131,7 +1131,7 @@
     },
     {
         "path": "additional_info.vehicle.passport.type",
-        "description": "Дополнительная информация: Вид электронного паспорта",
+        "description": "Дополнительная информация: Вид паспорта ТС",
         "types": [
             "string"
         ],
@@ -1141,7 +1141,7 @@
     },
     {
         "path": "additional_info.vehicle.passport.status",
-        "description": "Дополнительная информация: Статус электронного паспорта",
+        "description": "Дополнительная информация: Статус паспорта ТС",
         "types": [
             "string"
         ],
@@ -1617,7 +1617,7 @@
         ]
     },
     {
-        "path": "additional_info.vehicle.car_scrappage_fees",
+        "path": "additional_info.vehicle.utilization_tax",
         "description": "Дополнительная информация: Сведения об уплате утилизационного сбора",
         "types": [
             "string"
@@ -1627,7 +1627,7 @@
         ]
     },
     {
-        "path": "additional_info.vehicle.custom_registration",
+        "path": "additional_info.vehicle.customs_registration",
         "description": "Дополнительная информация: Сведения о выпуске (таможенное оформление)",
         "types": [
             "string"

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -197,6 +197,8 @@
                 },
                 "has_dublicate": null,
                 "number": null,
+                "type": null,
+                "status": null,
                 "org": {
                     "name": null
                 }
@@ -217,6 +219,12 @@
                 }
             },
             "exported": null,
+            "car_scrappage_fees": null,
+            "custom_registration": null,
+            "restriction": {
+                "customs": null,
+                "other": null
+            },
             "techreglament_category": {
                 "code": null,
                 "description": null

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -219,8 +219,8 @@
                 }
             },
             "exported": null,
-            "car_scrappage_fees": null,
-            "custom_registration": null,
+            "utilization_tax": null,
+            "customs_registration": null,
             "restriction": {
                 "customs": null,
                 "other": null

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -223,8 +223,8 @@
                 }
             },
             "exported": true,
-            "car_scrappage_fees": "РФ уплачен",
-            "custom_registration": "Отсутствуют",
+            "utilization_tax": "РФ уплачен",
+            "customs_registration": "Отсутствуют",
             "restriction": {
                 "customs": "Отсутствуют",
                 "other": "СВЕДЕНИЯ ОБ ОГРАНИЧЕНИЯХ ОТСУТСТВУЮТ"

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -197,6 +197,8 @@
                 },
                 "has_dublicate": false,
                 "number": "8047307033",
+                "type": "Электронный паспорт транспортного средства",
+                "status": "действующий",
                 "org": {
                     "name": "ОАО СервисКазань"
                 }
@@ -221,6 +223,12 @@
                 }
             },
             "exported": true,
+            "car_scrappage_fees": "РФ уплачен",
+            "custom_registration": "Отсутствуют",
+            "restriction": {
+                "customs": "Отсутствуют",
+                "other": "СВЕДЕНИЯ ОБ ОГРАНИЧЕНИЯХ ОТСУТСТВУЮТ"
+            },
             "techreglament_category": {
                 "code": "L",
                 "description": "Мототранспортные средства"

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -436,7 +436,8 @@
                                 "base.basalt",
                                 "gibdd.history",
                                 "base.alt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "elpts.online"
                             ]
                         },
                         "body": {
@@ -635,7 +636,8 @@
                                 "base.basalt",
                                 "gibdd.history",
                                 "base.alt",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "elpts.online"
                             ]
                         },
                         "body": {
@@ -2241,7 +2243,34 @@
                                         "base.ext",
                                         "base.alt",
                                         "base.basalt",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "elpts.online"
+                                    ]
+                                },
+                                "type": {
+                                    "description": "Вид электронного паспорта",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "examples": [
+                                        "Электронный паспорт транспортного средства"
+                                    ],
+                                    "fillable_by": [
+                                        "elpts.online"
+                                    ]
+                                },
+                                "status": {
+                                    "description": "Статус электронного паспорта",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "examples": [
+                                        "действующий"
+                                    ],
+                                    "fillable_by": [
+                                        "elpts.online"
                                     ]
                                 },
                                 "org": {
@@ -2385,6 +2414,64 @@
                                 "base",
                                 "base.ext"
                             ]
+                        },
+                        "car_scrappage_fees": {
+                            "description": "Сведения об уплате утилизационного сбора",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "examples": [
+                                "РФ уплачен"
+                            ],
+                            "fillable_by": [
+                                "elpts.online"
+                            ]
+                        },
+                        "custom_registration": {
+                            "description": "Сведения о выпуске (таможенное оформление)",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "examples": [
+                                "Отсутствуют"
+                            ],
+                            "fillable_by": [
+                                "elpts.online"
+                            ]
+                        },
+                        "restriction": {
+                             "type": "object",
+                             "additionalProperties": false,
+                             "properties": {
+                                 "customs": {
+                                     "description": "Таможенные ограничения",
+                                     "type": [
+                                         "string",
+                                         "null"
+                                     ],
+                                     "examples": [
+                                         "Отсутствуют"
+                                     ],
+                                     "fillable_by": [
+                                         "elpts.online"
+                                     ]
+                                 },
+                                 "other": {
+                                     "description": "Ограничения (обременения) за исключением таможенных",
+                                     "type": [
+                                         "string",
+                                         "null"
+                                     ],
+                                     "examples": [
+                                         "Отсутствуют"
+                                     ],
+                                     "fillable_by": [
+                                         "elpts.online"
+                                     ]
+                                 }
+                             }
                         },
                         "techreglament_category": {
                             "type": "object",

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -2248,7 +2248,7 @@
                                     ]
                                 },
                                 "type": {
-                                    "description": "Вид электронного паспорта",
+                                    "description": "Вид паспорта ТС",
                                     "type": [
                                         "string",
                                         "null"
@@ -2261,7 +2261,7 @@
                                     ]
                                 },
                                 "status": {
-                                    "description": "Статус электронного паспорта",
+                                    "description": "Статус паспорта ТС",
                                     "type": [
                                         "string",
                                         "null"
@@ -2415,7 +2415,7 @@
                                 "base.ext"
                             ]
                         },
-                        "car_scrappage_fees": {
+                        "utilization_tax": {
                             "description": "Сведения об уплате утилизационного сбора",
                             "type": [
                                 "string",
@@ -2428,7 +2428,7 @@
                                 "elpts.online"
                             ]
                         },
-                        "custom_registration": {
+                        "customs_registration": {
                             "description": "Сведения о выпуске (таможенное оформление)",
                             "type": [
                                 "string",

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -348,5 +348,10 @@
         "name": "repairs.history.registry",
         "description": "Реестр истории ремонтных работ",
         "enabled": true
+    },
+    {
+        "name": "elpts.online",
+        "description": "Данные по ЭПТС",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
## Description

### Added

- Field with path `additional_info.vehicle.passport.type`
- Field with path `additional_info.vehicle.passport.status`
- Field with path `additional_info.vehicle.car_scrappage_fees`
- Field with path `additional_info.vehicle.custom_registration`
- Field with path `additional_info.vehicle.restriction.customs`
- Field with path `additional_info.vehicle.restriction.other`

### Changed

- Field with path `identifiers.vehicle.pts` also fillable by `elpts.online`
- Field with path `identifiers_masked.vehicle.pts` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.passport.number` also fillable by `elpts.online`
