### PR TITLE
Draft: Add `fines.base.uin` and `fines.base.dln` sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,12 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Field with path `fines.items[].wire.okato` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].location.raw` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].location.coordinates` also fillable by `fines.base.uin` and `fines.base.dln`
--- Field with path `fines.items[].fssp.date` also fillable by `fines.base.uin` and `fines.base.dln`
--- Field with path `fines.items[].fssp.is_proceed` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].fssp.date` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].fssp.is_proceed` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].fssp.enforcement_proceeding.number` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].fssp.enforcement_proceeding.contact` also fillable by `fines.base.uin` and `fines.base.dln`
--- Field with path `fines.items[].photos[].type` also fillable by `fines.base.uin` and `fines.base.dln`
--- Field with path `fines.items[].photos[].uri` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].photos[].type` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].photos[].uri` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].payer.name` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].payer.identifier.type` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].payer.identifier.number` also fillable by `fines.base.uin` and `fines.base.dln`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,18 +35,13 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Field with path `fines.items[].wire.okato` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].location.raw` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].location.coordinates` also fillable by `fines.base.uin` and `fines.base.dln`
-- Field with path `fines.items[].fssp.date` also fillable by `fines.base.uin` and `fines.base.dln`
-- Field with path `fines.items[].fssp.is_proceed` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].fssp.enforcement_proceeding.number` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].fssp.enforcement_proceeding.contact` also fillable by `fines.base.uin` and `fines.base.dln`
-- Field with path `fines.items[].photos[].type` also fillable by `fines.base.uin` and `fines.base.dln`
-- Field with path `fines.items[].photos[].uri` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].payer.name` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].payer.identifier.type` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].payer.identifier.number` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.date.update` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.has_fines` also fillable by `fines.base.uin` and `fines.base.dln`
-
 
 ## v3.150.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,55 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Source `fines.base.uin`
+- Source `fines.base.dln`
+- Field with path `fines.items[].date.event` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].date.accident` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].article.code` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].article.description` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].uin` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].description` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].vendor.name` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].vendor.type` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].vendor.code` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].amount.value` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].amount.total` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].discount.percent` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].discount.date.end` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].need_payment` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].is_paid` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.user.name` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.user.tin` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.user.kpp` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.bank.account.number` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.bank.name` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.payment.purpose` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.kbk` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].wire.okato` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].location.raw` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].location.coordinates` also fillable by `fines.base.uin` and `fines.base.dln`
+-- Field with path `fines.items[].fssp.date` also fillable by `fines.base.uin` and `fines.base.dln`
+-- Field with path `fines.items[].fssp.is_proceed` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].fssp.enforcement_proceeding.number` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].fssp.enforcement_proceeding.contact` also fillable by `fines.base.uin` and `fines.base.dln`
+-- Field with path `fines.items[].photos[].type` also fillable by `fines.base.uin` and `fines.base.dln`
+-- Field with path `fines.items[].photos[].uri` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].payer.name` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].payer.identifier.type` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.items[].payer.identifier.number` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.date.update` also fillable by `fines.base.uin` and `fines.base.dln`
+- Field with path `fines.has_fines` also fillable by `fines.base.uin` and `fines.base.dln`
+
+
 ## v3.150.0
 
 ### Added
 
+- Source `elpts.online`
 - Field with path `additional_info.vehicle.passport.type`
 - Field with path `additional_info.vehicle.passport.status`
 - Field with path `additional_info.vehicle.utilization_tax`

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -5273,7 +5273,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5284,7 +5286,9 @@
         ],
         "fillable_by": [
             "fines.base",
-            "gibdd.fines"
+            "gibdd.fines",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5299,7 +5303,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5314,7 +5320,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5327,7 +5335,9 @@
             "fines.base",
             "gibdd.fines",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5342,7 +5352,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5356,7 +5368,9 @@
             "gibdd.fines",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5367,7 +5381,9 @@
         ],
         "fillable_by": [
             "fines.registry",
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5377,7 +5393,9 @@
             "string"
         ],
         "fillable_by": [
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5390,7 +5408,9 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext"
+            "fines.base.ext",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5405,7 +5425,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5420,7 +5442,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5435,7 +5459,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5448,7 +5474,9 @@
             "fines.base",
             "gibdd.fines",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5463,7 +5491,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5476,7 +5506,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5489,7 +5521,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5502,7 +5536,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5515,7 +5551,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5528,7 +5566,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5541,7 +5581,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5554,7 +5596,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5568,7 +5612,9 @@
             "gibdd.fines",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5581,7 +5627,9 @@
             "fines.base",
             "fines.alt",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5596,7 +5644,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5609,7 +5659,9 @@
             "fines.base",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5620,7 +5672,9 @@
         ],
         "fillable_by": [
             "fines.base",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5653,7 +5707,9 @@
         ],
         "fillable_by": [
             "fines.registry",
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5664,7 +5720,9 @@
         ],
         "fillable_by": [
             "fines.registry",
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5697,7 +5755,9 @@
         ],
         "fillable_by": [
             "fines.registry",
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5708,7 +5768,9 @@
         ],
         "fillable_by": [
             "fines.registry",
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5719,7 +5781,9 @@
         ],
         "fillable_by": [
             "fines.registry",
-            "fines.base"
+            "fines.base",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {
@@ -5734,7 +5798,9 @@
             "fines.alt",
             "fines.madiampp",
             "fines.base.ext",
-            "fines.registry"
+            "fines.registry",
+            "fines.base.dln",
+            "fines.base.uin"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -4992,7 +4992,10 @@
                                             "fines.alt",
                                             "fines.madiampp",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
+
                                         ]
                                     },
                                     "accident": {
@@ -5010,7 +5013,9 @@
                                         ],
                                         "fillable_by": [
                                             "fines.base",
-                                            "gibdd.fines"
+                                            "gibdd.fines",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     }
                                 }
@@ -5034,7 +5039,9 @@
                                             "fines.alt",
                                             "fines.madiampp",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "description": {
@@ -5052,7 +5059,9 @@
                                             "fines.alt",
                                             "fines.madiampp",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     }
                                 }
@@ -5070,7 +5079,9 @@
                                     "fines.base",
                                     "gibdd.fines",
                                     "fines.base.ext",
-                                    "fines.registry"
+                                    "fines.registry",
+                                    "fines.base.dln",
+                                    "fines.base.uin"
                                 ]
                             },
                             "description": {
@@ -5088,7 +5099,9 @@
                                     "fines.alt",
                                     "fines.madiampp",
                                     "fines.base.ext",
-                                    "fines.registry"
+                                    "fines.registry",
+                                    "fines.base.dln",
+                                    "fines.base.uin"
                                 ]
                             },
                             "vendor": {
@@ -5109,7 +5122,9 @@
                                             "gibdd.fines",
                                             "fines.alt",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "type": {
@@ -5130,7 +5145,9 @@
                                         ],
                                         "fillable_by": [
                                             "fines.registry",
-                                            "fines.base"
+                                            "fines.base",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "code": {
@@ -5143,7 +5160,9 @@
                                             "1165080"
                                         ],
                                         "fillable_by": [
-                                            "fines.base"
+                                            "fines.base",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     }
                                 }
@@ -5165,7 +5184,9 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext"
+                                            "fines.base.ext",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "total": {
@@ -5183,7 +5204,9 @@
                                             "fines.alt",
                                             "fines.madiampp",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     }
                                 }
@@ -5208,7 +5231,9 @@
                                             "fines.alt",
                                             "fines.madiampp",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "date": {
@@ -5234,7 +5259,9 @@
                                                     "fines.alt",
                                                     "fines.madiampp",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             }
                                         }
@@ -5254,7 +5281,9 @@
                                     "fines.base",
                                     "gibdd.fines",
                                     "fines.base.ext",
-                                    "fines.registry"
+                                    "fines.registry",
+                                    "fines.base.dln",
+                                    "fines.base.uin"
                                 ]
                             },
                             "is_paid": {
@@ -5272,7 +5301,9 @@
                                     "fines.alt",
                                     "fines.madiampp",
                                     "fines.base.ext",
-                                    "fines.registry"
+                                    "fines.registry",
+                                    "fines.base.dln",
+                                    "fines.base.uin"
                                 ]
                             },
                             "wire": {
@@ -5296,7 +5327,9 @@
                                                     "fines.base",
                                                     "fines.alt",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             },
                                             "tin": {
@@ -5312,7 +5345,9 @@
                                                     "fines.base",
                                                     "fines.alt",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             },
                                             "kpp": {
@@ -5332,7 +5367,9 @@
                                                     "fines.base",
                                                     "fines.alt",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             }
                                         }
@@ -5358,7 +5395,9 @@
                                                             "fines.base",
                                                             "fines.alt",
                                                             "fines.base.ext",
-                                                            "fines.registry"
+                                                            "fines.registry",
+                                                            "fines.base.dln",
+                                                            "fines.base.uin"
                                                         ]
                                                     }
                                                 }
@@ -5376,7 +5415,9 @@
                                                     "fines.base",
                                                     "fines.alt",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             },
                                             "bik": {
@@ -5392,7 +5433,9 @@
                                                     "fines.base",
                                                     "fines.alt",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             }
                                         }
@@ -5414,7 +5457,9 @@
                                                     "fines.base",
                                                     "fines.alt",
                                                     "fines.base.ext",
-                                                    "fines.registry"
+                                                    "fines.registry",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             }
                                         }
@@ -5433,7 +5478,9 @@
                                             "gibdd.fines",
                                             "fines.alt",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "okato": {
@@ -5449,7 +5496,9 @@
                                             "fines.base",
                                             "fines.alt",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     }
                                 }
@@ -5471,7 +5520,9 @@
                                             "fines.base",
                                             "fines.madiampp",
                                             "fines.base.ext",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "coordinates": {
@@ -5485,7 +5536,9 @@
                                         ],
                                         "fillable_by": [
                                             "fines.base",
-                                            "fines.registry"
+                                            "fines.registry",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     }
                                 }
@@ -5541,7 +5594,9 @@
                                                 ],
                                                 "fillable_by": [
                                                     "fines.registry",
-                                                    "fines.base"
+                                                    "fines.base",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             },
                                             "contact": {
@@ -5555,7 +5610,9 @@
                                                 ],
                                                 "fillable_by": [
                                                     "fines.registry",
-                                                    "fines.base"
+                                                    "fines.base",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             }
                                         }
@@ -5577,7 +5634,9 @@
                                         ],
                                         "fillable_by": [
                                             "fines.registry",
-                                            "fines.base"
+                                            "fines.base",
+                                            "fines.base.dln",
+                                            "fines.base.uin"
                                         ]
                                     },
                                     "identifier": {
@@ -5595,7 +5654,9 @@
                                                 ],
                                                 "fillable_by": [
                                                     "fines.registry",
-                                                    "fines.base"
+                                                    "fines.base",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             },
                                             "number": {
@@ -5609,7 +5670,9 @@
                                                 ],
                                                 "fillable_by": [
                                                     "fines.registry",
-                                                    "fines.base"
+                                                    "fines.base",
+                                                    "fines.base.dln",
+                                                    "fines.base.uin"
                                                 ]
                                             }
                                         }
@@ -5678,7 +5741,9 @@
                         "fines.alt",
                         "fines.madiampp",
                         "fines.base.ext",
-                        "fines.registry"
+                        "fines.registry",
+                        "fines.base.dln",
+                        "fines.base.uin"
                     ]
                 },
                 "date": {
@@ -5703,7 +5768,9 @@
                                 "fines.alt",
                                 "fines.madiampp",
                                 "fines.base.ext",
-                                "fines.registry"
+                                "fines.registry",
+                                "fines.base.dln",
+                                "fines.base.uin"
                             ]
                         }
                     }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -353,5 +353,15 @@
         "name": "elpts.online",
         "description": "Данные по ЭПТС",
         "enabled": true
+    },
+    {
+        "name": "fines.base.uin",
+        "description": "Данные о штрафах, оформленных на ТС по УИН",
+        "enabled": true
+    },
+    {
+        "name": "fines.base.dln",
+        "description": "Данные о штрафах, оформленных на ТС по ВУ",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
### Added

- Source `fines.base.uin`
- Source `fines.base.dln`
- Field with path `fines.items[].date.event` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].date.accident` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].article.code` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].article.description` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].uin` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].description` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].vendor.name` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].vendor.type` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].vendor.code` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].amount.value` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].amount.total` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].discount.percent` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].discount.date.end` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].need_payment` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].is_paid` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.user.name` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.user.tin` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.user.kpp` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.bank.account.number` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.bank.name` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.payment.purpose` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.kbk` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].wire.okato` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].location.raw` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].location.coordinates` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].fssp.enforcement_proceeding.number` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].fssp.enforcement_proceeding.contact` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].payer.name` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].payer.identifier.type` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.items[].payer.identifier.number` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.date.update` also fillable by `fines.base.uin` and `fines.base.dln`
- Field with path `fines.has_fines` also fillable by `fines.base.uin` and `fines.base.dln`
