### PR TITLE
Add source 'vin.decoder'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Source `vin.decoder`
+
+### Changed
+
+- Field with path `tech_data.brand.id` also fillable by `vin.decoder`
+- Field with path `tech_data.brand.name.original` also fillable by `vin.decoder`
+- Field with path `tech_data.brand.name.normalized` also fillable by `vin.decoder`
+- Field with path `tech_data.model.id` also fillable by `vin.decoder`
+- Field with path `tech_data.model.name.original` also fillable by `vin.decoder`
+- Field with path `tech_data.model.name.normalized` also fillable by `vin.decoder`
+- Field with path `tech_data.year` also fillable by `vin.decoder`
+- Field with path `tech_data.engine.fuel.type` also fillable by `vin.decoder`
+- Field with path `tech_data.engine.fuel.type_id` also fillable by `vin.decoder`
+- Field with path `tech_data.engine.volume` also fillable by `vin.decoder`
+- Field with path `tech_data.engine.power.hp` also fillable by `vin.decoder`
+- Field with path `tech_data.engine.power.kw` also fillable by `vin.decoder`
+- Field with path `tech_data.wheel.position` also fillable by `vin.decoder`
+- Field with path `tech_data.wheel.position_id` also fillable by `vin.decoder`
+- Field with path `tech_data.wheel.position_code` also fillable by `vin.decoder`
+- Field with path `tech_data.date.update` also fillable by `vin.decoder`
+
 ## v3.151.1
 
 ### Changed
@@ -16,6 +41,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Source `fines.base.uin`
 - Source `fines.base.dln`
+
+### Changed
+
 - Field with path `fines.items[].date.event` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].date.accident` also fillable by `fines.base.uin` and `fines.base.dln`
 - Field with path `fines.items[].article.code` also fillable by `fines.base.uin` and `fines.base.dln`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Added
 
 - Source `vin.decoder`
+- Field with path `tech_data.filled_by.provider`
 
 ### Changed
 

--- a/__tests__/fields/fields_list.test.ts
+++ b/__tests__/fields/fields_list.test.ts
@@ -15,6 +15,7 @@ const non_fillable_fields: {[k: string]: string[]} = {
         'tech_data.manufacturer.name',
         'tech_data.brand.name.rus',
         'tech_data.transmission.type',
+        'tech_data.filled_by.provider',
         'calculate.tax.moscow.yearly.amount',
         'calculate.tax.regions.yearly.amount',
         'utilizations.items[].org.name',

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -254,7 +254,8 @@
             "string"
         ],
         "fillable_by": [
-            "references.base"
+            "references.base",
+            "vin.decoder"
         ]
     },
     {
@@ -277,7 +278,8 @@
             "eaisto.registry",
             "base.registry.retry",
             "gibdd.history.registry",
-            "customs.fts"
+            "customs.fts",
+            "vin.decoder"
         ]
     },
     {
@@ -287,7 +289,8 @@
             "string"
         ],
         "fillable_by": [
-            "references.base"
+            "references.base",
+            "vin.decoder"
         ]
     },
     {
@@ -315,7 +318,8 @@
             "string"
         ],
         "fillable_by": [
-            "references.base"
+            "references.base",
+            "vin.decoder"
         ]
     },
     {
@@ -330,7 +334,8 @@
             "gibdd.diagnostic.cards",
             "base.basalt",
             "eaisto.registry",
-            "customs.base"
+            "customs.base",
+            "vin.decoder"
         ]
     },
     {
@@ -340,7 +345,8 @@
             "string"
         ],
         "fillable_by": [
-            "references.base"
+            "references.base",
+            "vin.decoder"
         ]
     },
     {
@@ -444,7 +450,8 @@
             "eaisto.registry",
             "regactions.registry",
             "gibdd.history.registry",
-            "customs.base"
+            "customs.base",
+            "vin.decoder"
         ]
     },
     {
@@ -472,7 +479,8 @@
             "base.alt",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "vin.decoder"
         ]
     },
     {
@@ -488,7 +496,8 @@
             "base.basalt",
             "customs.base",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "vin.decoder"
         ]
     },
     {
@@ -536,7 +545,8 @@
             "base.alt",
             "regactions.registry",
             "gibdd.history.registry",
-            "customs.base"
+            "customs.base",
+            "vin.decoder"
         ]
     },
     {
@@ -555,7 +565,8 @@
             "base.registry",
             "base.registry.retry",
             "gibdd.history.registry",
-            "customs.base"
+            "customs.base",
+            "vin.decoder"
         ]
     },
     {
@@ -573,7 +584,8 @@
             "base.registry",
             "base.registry.retry",
             "gibdd.history.registry",
-            "customs.base"
+            "customs.base",
+            "vin.decoder"
         ]
     },
     {
@@ -693,7 +705,8 @@
             "base.alt",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "vin.decoder"
         ]
     },
     {
@@ -708,7 +721,8 @@
             "base.alt",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "vin.decoder"
         ]
     },
     {
@@ -720,7 +734,8 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "vin.decoder"
         ]
     },
     {
@@ -882,7 +897,8 @@
             "gibdd.diagnostic.cards",
             "eaisto.registry",
             "gibdd.history.registry",
-            "customs.fts"
+            "customs.fts",
+            "vin.decoder"
         ]
     },
     {

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -879,6 +879,14 @@
         ]
     },
     {
+        "path": "tech_data.filled_by.provider",
+        "description": "Характеристики ТС: Поставщик данных",
+        "types": [
+            "string"
+        ],
+        "fillable_by": []
+    },
+    {
         "path": "tech_data.date.update",
         "description": "Характеристики ТС: Дата обновления данных",
         "types": [

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -135,6 +135,9 @@
                 ]
             }
         ],
+        "filled_by": {
+            "provider": null
+        },
         "date": {
             "update": null
         }

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -135,6 +135,9 @@
                 ]
             }
         ],
+        "filled_by": {
+            "provider": "GIBDD"
+        },
         "date": {
             "update": "2020-01-16 22:10:00"
         }

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -743,7 +743,8 @@
                                 "ID_MARK_OPEL"
                             ],
                             "fillable_by": [
-                                "references.base"
+                                "references.base",
+                                "vin.decoder"
                             ]
                         },
                         "name": {
@@ -773,7 +774,8 @@
                                         "eaisto.registry",
                                         "base.registry.retry",
                                         "gibdd.history.registry",
-                                        "customs.fts"
+                                        "customs.fts",
+                                        "vin.decoder"
                                     ]
                                 },
                                 "rus": {
@@ -797,7 +799,8 @@
                                         "Opel"
                                     ],
                                     "fillable_by": [
-                                        "references.base"
+                                        "references.base",
+                                        "vin.decoder"
                                     ]
                                 }
                             }
@@ -841,7 +844,8 @@
                                 "ID_MARK_OPEL_MODEL_MONTEREY"
                             ],
                             "fillable_by": [
-                                "references.base"
+                                "references.base",
+                                "vin.decoder"
                             ]
                         },
                         "name": {
@@ -863,7 +867,8 @@
                                         "base.basalt",
                                         "eaisto.registry",
                                         "gibdd.diagnostic.cards",
-                                        "customs.base"
+                                        "customs.base",
+                                        "vin.decoder"
                                     ]
                                 },
                                 "normalized": {
@@ -876,7 +881,8 @@
                                         "Monterey"
                                     ],
                                     "fillable_by": [
-                                        "references.base"
+                                        "references.base",
+                                        "vin.decoder"
                                     ]
                                 }
                             }
@@ -1033,7 +1039,8 @@
                         "eaisto.registry",
                         "regactions.registry",
                         "gibdd.history.registry",
-                        "customs.base"
+                        "customs.base",
+                        "vin.decoder"
                     ]
                 },
                 "chassis": {
@@ -1089,7 +1096,8 @@
                                         "base.alt",
                                         "base.basalt",
                                         "regactions.registry",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "vin.decoder"
                                     ]
                                 },
                                 "type_id": {
@@ -1112,7 +1120,8 @@
                                         "base.basalt",
                                         "customs.base",
                                         "regactions.registry",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "vin.decoder"
                                     ]
                                 }
                             }
@@ -1184,7 +1193,8 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "gibdd.history.registry",
-                                "customs.base"
+                                "customs.base",
+                                "vin.decoder"
                             ]
                         },
                         "power": {
@@ -1211,7 +1221,8 @@
                                         "base.registry",
                                         "base.registry.retry",
                                         "gibdd.history.registry",
-                                        "customs.base"
+                                        "customs.base",
+                                        "vin.decoder"
                                     ]
                                 },
                                 "kw": {
@@ -1233,7 +1244,8 @@
                                         "base.registry",
                                         "base.registry.retry",
                                         "gibdd.history.registry",
-                                        "customs.base"
+                                        "customs.base",
+                                        "vin.decoder"
                                     ]
                                 }
                             }
@@ -1440,7 +1452,8 @@
                                 "base.alt",
                                 "base.basalt",
                                 "regactions.registry",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "vin.decoder"
                             ]
                         },
                         "position_id": {
@@ -1462,7 +1475,8 @@
                                 "base.alt",
                                 "base.basalt",
                                 "regactions.registry",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "vin.decoder"
                             ]
                         },
                         "position_code": {
@@ -1477,7 +1491,8 @@
                             "fillable_by": [
                                 "base",
                                 "base.ext",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "vin.decoder"
                             ]
                         }
                     }
@@ -1771,7 +1786,8 @@
                                 "eaisto.registry",
                                 "gibdd.diagnostic.cards",
                                 "gibdd.history.registry",
-                                "customs.fts"
+                                "customs.fts",
+                                "vin.decoder"
                             ]
                         }
                     }

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -316,6 +316,13 @@
             "pattern": "^\\d{4}\\-\\d{1,2}\\-\\d{1,2}$",
             "minLength": 8,
             "maxLength": 10
+        },
+        "tech_data_provider": {
+            "type": "string",
+            "enum": [
+                "GIBDD",
+                "VIN_DECODER"
+            ]
         }
     },
     "type": "object",
@@ -1754,6 +1761,27 @@
                                     }
                                 }
                             }
+                        }
+                    }
+                },
+                "filled_by": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "description": "Поставщик данных",
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "$ref": "#/definitions/tech_data_provider"
+                                }
+                            ],
+                            "examples": [
+                                "GIBDD"
+                            ],
+                            "fillable_by": []
                         }
                     }
                 },

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -363,5 +363,10 @@
         "name": "fines.base.dln",
         "description": "Данные о штрафах, оформленных на ТС по ВУ",
         "enabled": true
+    },
+    {
+        "name": "vin.decoder",
+        "description": "Вин декодер",
+        "enabled": true
     }
 ]

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -366,7 +366,7 @@
     },
     {
         "name": "vin.decoder",
-        "description": "Вин декодер",
+        "description": "Данные о ТС полученные по результатам расшифровки VIN кода",
         "enabled": true
     }
 ]


### PR DESCRIPTION
### Added

- Source `vin.decoder`

### Changed

- Field with path `tech_data.brand.id` also fillable by `vin.decoder`
- Field with path `tech_data.brand.name.original` also fillable by `vin.decoder`
- Field with path `tech_data.brand.name.normalized` also fillable by `vin.decoder`
- Field with path `tech_data.model.id` also fillable by `vin.decoder`
- Field with path `tech_data.model.name.original` also fillable by `vin.decoder`
- Field with path `tech_data.model.name.normalized` also fillable by `vin.decoder`
- Field with path `tech_data.year` also fillable by `vin.decoder`
- Field with path `tech_data.engine.fuel.type` also fillable by `vin.decoder`
- Field with path `tech_data.engine.fuel.type_id` also fillable by `vin.decoder`
- Field with path `tech_data.engine.volume` also fillable by `vin.decoder`
- Field with path `tech_data.engine.power.hp` also fillable by `vin.decoder`
- Field with path `tech_data.engine.power.kw` also fillable by `vin.decoder`
- Field with path `tech_data.wheel.position` also fillable by `vin.decoder`
- Field with path `tech_data.wheel.position_id` also fillable by `vin.decoder`
- Field with path `tech_data.wheel.position_code` also fillable by `vin.decoder`
- Field with path `tech_data.date.update` also fillable by `vin.decoder`