### PR TITLE
Change `accidents.has_accidents` fillable by list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Field `accidents.has_accidents` also fillable by:
+  - `gibdd.dtp`
+  - `dtp.registry`
+  - `insurance.dtp`
+  - `insurance.dtp.basalt`
+  - `insurance.registry`
+  - `insurance.vehicle.registry`
+  - `gibdd.stat.registry`
+
 ## v3.159.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -3727,7 +3727,13 @@
             "boolean"
         ],
         "fillable_by": [
-            "gibdd.dtp"
+            "gibdd.dtp",
+            "dtp.registry",
+            "insurance.dtp",
+            "insurance.dtp.basalt",
+            "insurance.registry",
+            "insurance.vehicle.registry",
+            "gibdd.stat.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -10522,7 +10522,13 @@
                         null
                     ],
                     "fillable_by": [
-                        "gibdd.dtp"
+                        "gibdd.dtp",
+                        "dtp.registry",
+                        "insurance.dtp",
+                        "insurance.dtp.basalt",
+                        "insurance.registry",
+                        "insurance.vehicle.registry",
+                        "gibdd.stat.registry"
                     ]
                 }
             }


### PR DESCRIPTION
## Description

### Changed

- Field `accidents.has_accidents` also fillable by:
  - `gibdd.dtp`
  - `dtp.registry`
  - `insurance.dtp`
  - `insurance.dtp.basalt`
  - `insurance.registry`
  - `insurance.vehicle.registry`
  - `gibdd.stat.registry`