### PR TITLE
Remove and disable deprecated sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Disabled source with name `insurance.dtp`
 - Disabled source with name `insurance.dtp.basalt`
 - Disabled source with name `insurance.registry`
+- Disabled source with name `owner.taxi.history`
 - Field `additional_info.vehicle.owner.enforcement_proceedings.has_proceedings` not fillable by `fssp.base` anymore
 - Field `tech_data.brand.name.original` not fillable by `customs.base` anymore
 - Fields `identifiers.*` not fillable by `customs.base` anymore
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Fields `accidents.*` not fillable by `insurance.dtp` anymore
 - Fields `accidents.*` not fillable by `insurance.dtp.basalt` anymore
 - Fields `accidents.*` not fillable by `insurance.registry` anymore
+- Fields `additional_info.vehicle.owner.taxi_history.*` not fillable by `owner.taxi.history` anymore
 
 ## v3.161.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Source `fssp.base`
+
+### Changed
+
+- Disabled source with name `customs.base`
+- Field `additional_info.vehicle.owner.enforcement_proceedings.has_proceedings` not fillable by `fssp.base` anymore
+- Field `tech_data.brand.name.original` not fillable by `customs.base` anymore
+- Fields `identifiers.*` not fillable by `customs.base` anymore
+- Fields `identifiers_masked.*` not fillable by `customs.base` anymore
+- Fields `tech_data.*` not fillable by `customs.base` anymore
+- Fields `customs.history.*` not fillable by `customs.base` anymore
+- Fields `mileages.items[].*` not fillable by `customs.base` anymore
+
 ## v3.161.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Disabled source with name `customs.base`
+- Disabled source with name `insurance.dtp`
+- Disabled source with name `insurance.dtp.basalt`
+- Disabled source with name `insurance.registry`
 - Field `additional_info.vehicle.owner.enforcement_proceedings.has_proceedings` not fillable by `fssp.base` anymore
 - Field `tech_data.brand.name.original` not fillable by `customs.base` anymore
 - Fields `identifiers.*` not fillable by `customs.base` anymore
@@ -20,6 +23,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Fields `tech_data.*` not fillable by `customs.base` anymore
 - Fields `customs.history.*` not fillable by `customs.base` anymore
 - Fields `mileages.items[].*` not fillable by `customs.base` anymore
+- Fields `accidents.*` not fillable by `insurance.dtp` anymore
+- Fields `accidents.*` not fillable by `insurance.dtp.basalt` anymore
+- Fields `accidents.*` not fillable by `insurance.registry` anymore
 
 ## v3.161.0
 

--- a/__tests__/Makefile
+++ b/__tests__/Makefile
@@ -14,10 +14,10 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 install: ## Install all dependencies
-	docker-compose run $(RUN_ARGS) node yarn install
+	docker compose run $(RUN_ARGS) node yarn install
 
 test: ## Execute tests
-	docker-compose run $(RUN_ARGS) node yarn test
+	docker compose run $(RUN_ARGS) node yarn test
 
 shell: ## Start shell into container with node
-	docker-compose run $(RUN_ARGS) node sh
+	docker compose run $(RUN_ARGS) node sh

--- a/__tests__/Makefile
+++ b/__tests__/Makefile
@@ -14,10 +14,10 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 install: ## Install all dependencies
-	docker compose run $(RUN_ARGS) node yarn install
+	docker-compose run $(RUN_ARGS) node yarn install
 
 test: ## Execute tests
-	docker compose run $(RUN_ARGS) node yarn test
+	docker-compose run $(RUN_ARGS) node yarn test
 
 shell: ## Start shell into container with node
-	docker compose run $(RUN_ARGS) node sh
+	docker-compose run $(RUN_ARGS) node sh

--- a/__tests__/sources/sources_list.test.ts
+++ b/__tests__/sources/sources_list.test.ts
@@ -12,7 +12,8 @@ const disabled_sources: {[k: string]: string[]} = {
         "references.transdekra",
         "rsaosago.base.ext",
         "gibdd.diagnostic.cards",
-        'references.oats'
+        "references.oats",
+        "customs.base"
     ]
 };
 // for each group of specifications...

--- a/__tests__/sources/sources_list.test.ts
+++ b/__tests__/sources/sources_list.test.ts
@@ -11,9 +11,13 @@ const disabled_sources: {[k: string]: string[]} = {
         "ramiosago.base",
         "references.transdekra",
         "rsaosago.base.ext",
+        "rsaosago.base.ext",
         "gibdd.diagnostic.cards",
         "references.oats",
-        "customs.base"
+        "customs.base",
+        "insurance.dtp",
+        "insurance.dtp.basalt",
+        "insurance.registry"
     ]
 };
 // for each group of specifications...

--- a/__tests__/sources/sources_list.test.ts
+++ b/__tests__/sources/sources_list.test.ts
@@ -17,7 +17,8 @@ const disabled_sources: {[k: string]: string[]} = {
         "customs.base",
         "insurance.dtp",
         "insurance.dtp.basalt",
-        "insurance.registry"
+        "insurance.registry",
+        "owner.taxi.history"
     ]
 };
 // for each group of specifications...

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -973,9 +973,7 @@
         "types": [
             "boolean"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.actuality.date",
@@ -983,9 +981,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.reg_num",
@@ -993,9 +989,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.brand_name_original",
@@ -1003,9 +997,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].vehicle.model_name_original",
@@ -1013,9 +1005,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].full_number",
@@ -1023,9 +1013,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].number",
@@ -1033,9 +1021,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].issued",
@@ -1043,9 +1029,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.taxi_licenses.items[].region.code",
@@ -1053,9 +1037,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.probable_use.items[].reg_num",
@@ -1063,9 +1045,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.taxi_history.probable_use.items[].date",
@@ -1073,9 +1053,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "owner.taxi.history"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.sts.date.receive",

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -18,8 +18,7 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -87,8 +86,7 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -108,8 +106,7 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -143,8 +140,7 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -212,8 +208,7 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -233,8 +228,7 @@
             "eaisto.registry",
             "base.registry.retry",
             "eaisto.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -268,7 +262,6 @@
             "base",
             "base.ext",
             "gibdd.history",
-            "customs.base",
             "gibdd.eaisto",
             "base.alt",
             "regactions.registry",
@@ -334,7 +327,6 @@
             "gibdd.diagnostic.cards",
             "base.basalt",
             "eaisto.registry",
-            "customs.base",
             "vin.decoder"
         ]
     },
@@ -430,8 +422,7 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "base.alt",
-            "customs.base"
+            "base.alt"
         ]
     },
     {
@@ -450,7 +441,6 @@
             "eaisto.registry",
             "regactions.registry",
             "gibdd.history.registry",
-            "customs.base",
             "vin.decoder"
         ]
     },
@@ -475,7 +465,6 @@
         "fillable_by": [
             "base",
             "base.ext",
-            "customs.base",
             "base.alt",
             "base.basalt",
             "regactions.registry",
@@ -494,7 +483,6 @@
             "base.ext",
             "base.alt",
             "base.basalt",
-            "customs.base",
             "regactions.registry",
             "gibdd.history.registry",
             "vin.decoder"
@@ -512,8 +500,7 @@
             "base.alt",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -527,8 +514,7 @@
             "base.ext",
             "base.basalt",
             "base.alt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -545,7 +531,6 @@
             "base.alt",
             "regactions.registry",
             "gibdd.history.registry",
-            "customs.base",
             "vin.decoder"
         ]
     },
@@ -565,7 +550,6 @@
             "base.registry",
             "base.registry.retry",
             "gibdd.history.registry",
-            "customs.base",
             "vin.decoder"
         ]
     },
@@ -584,7 +568,6 @@
             "base.registry",
             "base.registry.retry",
             "gibdd.history.registry",
-            "customs.base",
             "vin.decoder"
         ]
     },
@@ -599,8 +582,7 @@
             "base.ext",
             "base.basalt",
             "regactions.registry",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -615,8 +597,7 @@
             "gibdd.eaisto",
             "base.basalt",
             "base.alt",
-            "regactions.registry",
-            "customs.base"
+            "regactions.registry"
         ]
     },
     {
@@ -633,8 +614,7 @@
             "base.basalt",
             "regactions.registry",
             "base.registry",
-            "base.registry.retry",
-            "customs.base"
+            "base.registry.retry"
         ]
     },
     {
@@ -674,8 +654,7 @@
             "base.ext",
             "base.alt",
             "base.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -689,8 +668,7 @@
             "base.ext",
             "base.alt",
             "base.basalt",
-            "gibdd.history.registry",
-            "customs.base"
+            "gibdd.history.registry"
         ]
     },
     {
@@ -897,7 +875,6 @@
             "base",
             "base.ext",
             "gibdd.history",
-            "customs.base",
             "gibdd.eaisto",
             "base.alt",
             "base.basalt",
@@ -975,9 +952,7 @@
         "types": [
             "boolean"
         ],
-        "fillable_by": [
-            "fssp.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "additional_info.vehicle.owner.geo",
@@ -4588,7 +4563,6 @@
             "string"
         ],
         "fillable_by": [
-            "customs.base",
             "customs.fts",
             "base.basalt"
         ]
@@ -4599,9 +4573,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].document.number",
@@ -4610,7 +4582,6 @@
             "string"
         ],
         "fillable_by": [
-            "customs.base",
             "base.basalt"
         ]
     },
@@ -4621,7 +4592,6 @@
             "string"
         ],
         "fillable_by": [
-            "customs.base",
             "base.basalt"
         ]
     },
@@ -4631,9 +4601,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].tax.amount",
@@ -4641,9 +4609,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].price.amount",
@@ -4651,9 +4617,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].mileage",
@@ -4661,9 +4625,7 @@
         "types": [
             "integer"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].ecology.type",
@@ -4671,9 +4633,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].specification.type",
@@ -4681,9 +4641,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].specification.raw",
@@ -4691,9 +4649,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].owner.type",
@@ -4701,9 +4657,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].owner.value",
@@ -4711,9 +4665,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].owner.tin",
@@ -4721,9 +4673,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].country.from.name",
@@ -4732,7 +4682,6 @@
             "string"
         ],
         "fillable_by": [
-            "customs.base",
             "customs.fts",
             "base.basalt"
         ]
@@ -4743,9 +4692,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].country.to.name",
@@ -4753,9 +4700,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].country.to.code",
@@ -4763,9 +4708,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].utilization_tax.status",
@@ -4783,9 +4726,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].sender.tin",
@@ -4793,9 +4734,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].operation.type",
@@ -4803,9 +4742,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].country.original.name",
@@ -4813,9 +4750,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].country.original.code",
@@ -4823,9 +4758,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.items[].manufacturer.name",
@@ -4833,9 +4766,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "customs.base"
-        ]
+        "fillable_by": []
     },
     {
         "path": "customs.history.date.update",
@@ -4844,7 +4775,6 @@
             "string"
         ],
         "fillable_by": [
-            "customs.base",
             "customs.fts",
             "base.basalt"
         ]
@@ -5996,7 +5926,6 @@
             "ads.base",
             "service.history",
             "repairs.history",
-            "customs.base",
             "images.archive",
             "mileages.registry",
             "service.history.fitservice",
@@ -6019,7 +5948,6 @@
             "ads.base",
             "service.history",
             "repairs.history",
-            "customs.base",
             "images.archive",
             "mileages.registry",
             "service.history.fitservice",
@@ -6050,7 +5978,6 @@
             "ads.base",
             "service.history",
             "repairs.history",
-            "customs.base",
             "images.archive",
             "mileages.registry",
             "service.history.fitservice",

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -3624,9 +3624,6 @@
             "string"
         ],
         "fillable_by": [
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry"
         ]
     },
@@ -3637,9 +3634,6 @@
             "string"
         ],
         "fillable_by": [
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry"
         ]
     },
@@ -3650,9 +3644,6 @@
             "string"
         ],
         "fillable_by": [
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry"
         ]
     },
@@ -3663,9 +3654,6 @@
             "string"
         ],
         "fillable_by": [
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry"
         ]
     },
@@ -3676,9 +3664,6 @@
             "string"
         ],
         "fillable_by": [
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry"
         ]
     },
@@ -3689,9 +3674,6 @@
             "string"
         ],
         "fillable_by": [
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry"
         ]
     },
@@ -3704,9 +3686,6 @@
         "fillable_by": [
             "gibdd.dtp",
             "dtp.registry",
-            "insurance.dtp",
-            "insurance.dtp.basalt",
-            "insurance.registry",
             "insurance.vehicle.registry",
             "gibdd.stat.registry"
         ]

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -366,8 +366,7 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         },
                         "reg_num": {
@@ -475,8 +474,7 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         },
                         "chassis": {
@@ -506,8 +504,7 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         }
                     }
@@ -575,8 +572,7 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         },
                         "reg_num": {
@@ -672,8 +668,7 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         },
                         "chassis": {
@@ -700,8 +695,7 @@
                                 "eaisto.registry",
                                 "base.registry.retry",
                                 "eaisto.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         }
                     }
@@ -771,7 +765,6 @@
                                         "base",
                                         "base.ext",
                                         "gibdd.history",
-                                        "customs.base",
                                         "gibdd.eaisto",
                                         "base.alt",
                                         "base.basalt",
@@ -874,7 +867,6 @@
                                         "base.basalt",
                                         "eaisto.registry",
                                         "gibdd.diagnostic.cards",
-                                        "customs.base",
                                         "vin.decoder"
                                     ]
                                 },
@@ -1018,8 +1010,7 @@
                                     "fillable_by": [
                                         "base",
                                         "base.ext",
-                                        "base.alt",
-                                        "customs.base"
+                                        "base.alt"
                                     ]
                                 }
                             }
@@ -1046,7 +1037,6 @@
                         "eaisto.registry",
                         "regactions.registry",
                         "gibdd.history.registry",
-                        "customs.base",
                         "vin.decoder"
                     ]
                 },
@@ -1099,7 +1089,6 @@
                                     "fillable_by": [
                                         "base",
                                         "base.ext",
-                                        "customs.base",
                                         "base.alt",
                                         "base.basalt",
                                         "regactions.registry",
@@ -1125,7 +1114,6 @@
                                         "base.ext",
                                         "base.alt",
                                         "base.basalt",
-                                        "customs.base",
                                         "regactions.registry",
                                         "gibdd.history.registry",
                                         "vin.decoder"
@@ -1154,8 +1142,7 @@
                                 "base.alt",
                                 "base.basalt",
                                 "regactions.registry",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         },
                         "model": {
@@ -1176,8 +1163,7 @@
                                         "base.ext",
                                         "base.alt",
                                         "base.basalt",
-                                        "gibdd.history.registry",
-                                        "customs.base"
+                                        "gibdd.history.registry"
                                     ]
                                 }
                             }
@@ -1200,7 +1186,6 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "gibdd.history.registry",
-                                "customs.base",
                                 "vin.decoder"
                             ]
                         },
@@ -1228,7 +1213,6 @@
                                         "base.registry",
                                         "base.registry.retry",
                                         "gibdd.history.registry",
-                                        "customs.base",
                                         "vin.decoder"
                                     ]
                                 },
@@ -1251,7 +1235,6 @@
                                         "base.registry",
                                         "base.registry.retry",
                                         "gibdd.history.registry",
-                                        "customs.base",
                                         "vin.decoder"
                                     ]
                                 }
@@ -1279,8 +1262,7 @@
                                                 "base.ext",
                                                 "base.basalt",
                                                 "regactions.registry",
-                                                "gibdd.history.registry",
-                                                "customs.base"
+                                                "gibdd.history.registry"
                                             ]
                                         }
                                     }
@@ -1309,8 +1291,7 @@
                                 "gibdd.eaisto",
                                 "base.alt",
                                 "base.basalt",
-                                "regactions.registry",
-                                "customs.base"
+                                "regactions.registry"
                             ]
                         },
                         "max": {
@@ -1331,8 +1312,7 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "base.registry",
-                                "base.registry.retry",
-                                "customs.base"
+                                "base.registry.retry"
                             ]
                         }
                     }
@@ -1408,8 +1388,7 @@
                                 "base.ext",
                                 "base.alt",
                                 "base.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         },
                         "type_id": {
@@ -1430,8 +1409,7 @@
                                 "base.ext",
                                 "base.alt",
                                 "base.basalt",
-                                "gibdd.history.registry",
-                                "customs.base"
+                                "gibdd.history.registry"
                             ]
                         }
                     }
@@ -1806,7 +1784,6 @@
                                 "base",
                                 "base.ext",
                                 "gibdd.history",
-                                "customs.base",
                                 "gibdd.eaisto",
                                 "base.alt",
                                 "base.basalt",
@@ -1960,9 +1937,7 @@
                                             "examples": [
                                                 true
                                             ],
-                                            "fillable_by": [
-                                                "fssp.base"
-                                            ]
+                                            "fillable_by": []
                                         }
                                     }
                                 },
@@ -6399,7 +6374,6 @@
                                                     "2016-04-05 00:00:00"
                                                 ],
                                                 "fillable_by": [
-                                                    "customs.base",
                                                     "customs.fts",
                                                     "base.basalt"
                                                 ]
@@ -6419,9 +6393,7 @@
                                                 "examples": [
                                                     "Таможенная выписка"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             },
                                             "number": {
                                                 "description": "Номер документа (декларации)",
@@ -6433,7 +6405,6 @@
                                                     "50302382\/017119\/0003860"
                                                 ],
                                                 "fillable_by": [
-                                                    "customs.base",
                                                     "base.basalt"
                                                 ]
                                             }
@@ -6453,7 +6424,6 @@
                                                     "ТАМОЖЕННОЕ УПРАВЛЕНИЕ"
                                                 ],
                                                 "fillable_by": [
-                                                    "customs.base",
                                                     "base.basalt"
                                                 ]
                                             }
@@ -6472,9 +6442,7 @@
                                                 "examples": [
                                                     "фуксия"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6491,9 +6459,7 @@
                                                 "examples": [
                                                     45690
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6510,9 +6476,7 @@
                                                 "examples": [
                                                     117400
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6525,9 +6489,7 @@
                                         "examples": [
                                             120
                                         ],
-                                        "fillable_by": [
-                                            "customs.base"
-                                        ]
+                                        "fillable_by": []
                                     },
                                     "ecology": {
                                         "type": "object",
@@ -6542,9 +6504,7 @@
                                                 "examples": [
                                                     "ЕВРО 0"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6561,9 +6521,7 @@
                                                 "examples": [
                                                     "Honda CR-X"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             },
                                             "raw": {
                                                 "description": "Спецификация, сырая строка",
@@ -6574,9 +6532,7 @@
                                                 "examples": [
                                                     "ЛЕГ.А\\\/М HONDA CR-X 3OZ53\/NXY8, 2007Г.В., БЕНЗИН, V=ДВ.2904СМ3, МОД.ДВ.LLT, 362КВТ, ЕВРО 0, КУЗОВ \"КУПЕ\", ФУКСИЯ, VIN: XSCMHTAT75L1N3467, ДВИГ.1KB6860064, ПР.120КМ."
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6601,9 +6557,7 @@
                                                 "examples": [
                                                     "LEGAL"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             },
                                             "value": {
                                                 "description": "Владелец ТС",
@@ -6614,9 +6568,7 @@
                                                 "examples": [
                                                     "ЗАО ВекторРечПив"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             },
                                             "tin": {
                                                 "description": "ИНН владельца ТС",
@@ -6627,9 +6579,7 @@
                                                 "examples": [
                                                     "1363519987"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6651,7 +6601,6 @@
                                                             "Бразилия"
                                                         ],
                                                         "fillable_by": [
-                                                            "customs.base",
                                                             "customs.fts",
                                                             "base.basalt"
                                                         ]
@@ -6665,9 +6614,7 @@
                                                         "examples": [
                                                             "BR"
                                                         ],
-                                                        "fillable_by": [
-                                                            "customs.base"
-                                                        ]
+                                                        "fillable_by": []
                                                     }
                                                 }
                                             },
@@ -6684,9 +6631,7 @@
                                                         "examples": [
                                                             "Россия"
                                                         ],
-                                                        "fillable_by": [
-                                                            "customs.base"
-                                                        ]
+                                                        "fillable_by": []
                                                     },
                                                     "code": {
                                                         "description": "Код страны импортера",
@@ -6697,9 +6642,7 @@
                                                         "examples": [
                                                             "RU"
                                                         ],
-                                                        "fillable_by": [
-                                                            "customs.base"
-                                                        ]
+                                                        "fillable_by": []
                                                     }
                                                 }
                                             },
@@ -6716,9 +6659,7 @@
                                                         "examples": [
                                                             "Россия"
                                                         ],
-                                                        "fillable_by": [
-                                                            "customs.base"
-                                                        ]
+                                                        "fillable_by": []
                                                     },
                                                     "code": {
                                                         "description": "Код страны происхождения",
@@ -6729,9 +6670,7 @@
                                                         "examples": [
                                                             "RU"
                                                         ],
-                                                        "fillable_by": [
-                                                            "customs.base"
-                                                        ]
+                                                        "fillable_by": []
                                                     }
                                                 }
                                             }
@@ -6774,9 +6713,7 @@
                                                 "examples": [
                                                     "ООО Автоторг"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             },
                                             "tin": {
                                                 "description": "ИНН отправителя",
@@ -6787,9 +6724,7 @@
                                                 "examples": [
                                                     "1363519987"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6808,9 +6743,7 @@
                                                     "IMPORT",
                                                     "REEXPORT"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     },
@@ -6827,9 +6760,7 @@
                                                 "examples": [
                                                     "AUDI AG"
                                                 ],
-                                                "fillable_by": [
-                                                    "customs.base"
-                                                ]
+                                                "fillable_by": []
                                             }
                                         }
                                     }
@@ -6853,7 +6784,6 @@
                                         "2020-02-11 22:10:00"
                                     ],
                                     "fillable_by": [
-                                        "customs.base",
                                         "customs.fts",
                                         "base.basalt"
                                     ]
@@ -11631,7 +11561,6 @@
                                             "ads.base",
                                             "service.history",
                                             "repairs.history",
-                                            "customs.base",
                                             "images.archive",
                                             "mileages.registry",
                                             "service.history.fitservice",
@@ -11660,7 +11589,6 @@
                                     "ads.base",
                                     "service.history",
                                     "repairs.history",
-                                    "customs.base",
                                     "images.archive",
                                     "mileages.registry",
                                     "service.history.fitservice",
@@ -11687,7 +11615,6 @@
                                             "ads.base",
                                             "service.history",
                                             "repairs.history",
-                                            "customs.base",
                                             "images.archive",
                                             "service.history.fitservice",
                                             "service.history.filter",
@@ -11726,7 +11653,6 @@
                                             "ads.base",
                                             "service.history",
                                             "repairs.history",
-                                            "customs.base",
                                             "images.archive",
                                             "mileages.registry",
                                             "service.history.fitservice",

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -2002,9 +2002,7 @@
                                             "examples": [
                                                 false
                                             ],
-                                            "fillable_by": [
-                                                "owner.taxi.history"
-                                            ]
+                                            "fillable_by": []
                                         },
                                         "taxi_licenses": {
                                             "type": "object",
@@ -2027,9 +2025,7 @@
                                                             "examples": [
                                                                 "2018-08-05 00:00:00"
                                                             ],
-                                                            "fillable_by": [
-                                                                "owner.taxi.history"
-                                                            ]
+                                                            "fillable_by": []
                                                         }
                                                     }
                                                 },
@@ -2052,9 +2048,7 @@
                                                                         "examples": [
                                                                             "A111AA196"
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "owner.taxi.history"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     },
                                                                     "brand_name_original": {
                                                                         "description": "Марка автомобиля",
@@ -2065,9 +2059,7 @@
                                                                         "examples": [
                                                                             "Hyundai"
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "owner.taxi.history"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     },
                                                                     "model_name_original": {
                                                                         "description": "Модель автомобиля",
@@ -2078,9 +2070,7 @@
                                                                         "examples": [
                                                                             "Sonata"
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "owner.taxi.history"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     }
                                                                 }
                                                             },
@@ -2093,9 +2083,7 @@
                                                                 "examples": [
                                                                     "91480"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "owner.taxi.history"
-                                                                ]
+                                                                "fillable_by": []
                                                             },
                                                             "number": {
                                                                 "description": "Регистрационный номер разрешения",
@@ -2106,9 +2094,7 @@
                                                                 "examples": [
                                                                     "91480"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "owner.taxi.history"
-                                                                ]
+                                                                "fillable_by": []
                                                             },
                                                             "issued": {
                                                                 "description": "Дата выдачи разрешения",
@@ -2123,9 +2109,7 @@
                                                                 "examples": [
                                                                     "2018-08-05 00:00:00"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "owner.taxi.history"
-                                                                ]
+                                                                "fillable_by": []
                                                             },
                                                             "region": {
                                                                 "type": "object",
@@ -2140,9 +2124,7 @@
                                                                         "examples": [
                                                                             "23"
                                                                         ],
-                                                                        "fillable_by": [
-                                                                            "owner.taxi.history"
-                                                                        ]
+                                                                        "fillable_by": []
                                                                     }
                                                                 }
                                                             }
@@ -2170,9 +2152,7 @@
                                                                 "examples": [
                                                                     "A111AA196"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "owner.taxi.history"
-                                                                ]
+                                                                "fillable_by": []
                                                             },
                                                             "date": {
                                                                 "description": "Вероятная дата",
@@ -2187,9 +2167,7 @@
                                                                 "examples": [
                                                                     "2018-08-05 00:00:00"
                                                                 ],
-                                                                "fillable_by": [
-                                                                    "owner.taxi.history"
-                                                                ]
+                                                                "fillable_by": []
                                                             }
                                                         }
                                                     }

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -10305,9 +10305,6 @@
                                         "2019-05-16 22:10:00"
                                     ],
                                     "fillable_by": [
-                                        "insurance.dtp",
-                                        "insurance.dtp.basalt",
-                                        "insurance.registry",
                                         "insurance.vehicle.registry"
                                     ]
                                 }
@@ -10337,9 +10334,6 @@
                                                     "2010-02-10 18:00:00"
                                                 ],
                                                 "fillable_by": [
-                                                    "insurance.dtp",
-                                                    "insurance.dtp.basalt",
-                                                    "insurance.registry",
                                                     "insurance.vehicle.registry"
                                                 ]
                                             }
@@ -10359,9 +10353,6 @@
                                                     "АСКО-Страхование"
                                                 ],
                                                 "fillable_by": [
-                                                    "insurance.dtp",
-                                                    "insurance.dtp.basalt",
-                                                    "insurance.registry",
                                                     "insurance.vehicle.registry"
                                                 ]
                                             }
@@ -10381,9 +10372,6 @@
                                                     "XXX"
                                                 ],
                                                 "fillable_by": [
-                                                    "insurance.dtp",
-                                                    "insurance.dtp.basalt",
-                                                    "insurance.registry",
                                                     "insurance.vehicle.registry"
                                                 ]
                                             },
@@ -10397,9 +10385,6 @@
                                                     "0023231246"
                                                 ],
                                                 "fillable_by": [
-                                                    "insurance.dtp",
-                                                    "insurance.dtp.basalt",
-                                                    "insurance.registry",
                                                     "insurance.vehicle.registry"
                                                 ]
                                             }
@@ -10423,9 +10408,6 @@
                                                     "2015-07-13 00:00:00"
                                                 ],
                                                 "fillable_by": [
-                                                    "insurance.dtp",
-                                                    "insurance.dtp.basalt",
-                                                    "insurance.registry",
                                                     "insurance.vehicle.registry"
                                                 ]
                                             }
@@ -10454,9 +10436,6 @@
                     "fillable_by": [
                         "gibdd.dtp",
                         "dtp.registry",
-                        "insurance.dtp",
-                        "insurance.dtp.basalt",
-                        "insurance.registry",
                         "insurance.vehicle.registry",
                         "gibdd.stat.registry"
                     ]

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -337,7 +337,7 @@
     {
         "name": "owner.taxi.history",
         "description": "История такси владельца ТС",
-        "enabled": true
+        "enabled": false
     },
     {
         "name": "repairs.history.registry",

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -227,7 +227,7 @@
     {
         "name": "insurance.dtp",
         "description": "Информация о ДТП из РСА (европротоколы)",
-        "enabled": true
+        "enabled": false
     },
     {
         "name": "arbitration.history",
@@ -277,7 +277,7 @@
     {
         "name": "insurance.dtp.basalt",
         "description": "Информация о ДТП (европротоколы)",
-        "enabled": true
+        "enabled": false
     },
     {
         "name": "fines.registry",
@@ -317,7 +317,7 @@
     {
         "name": "insurance.registry",
         "description": "Реестр европротоколов",
-        "enabled": true
+        "enabled": false
     },
     {
         "name": "fssp.base.executive",

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -67,7 +67,7 @@
     {
         "name": "customs.base",
         "description": "Данные о ТС содержащиеся в таможенной декларации",
-        "enabled": true
+        "enabled": false
     },
     {
         "name": "images.avtonomer",
@@ -202,11 +202,6 @@
     {
         "name": "gots.history",
         "description": "Размещение ТС на аукционах ГОТС",
-        "enabled": true
-    },
-    {
-        "name": "fssp.base",
-        "description": "Данные об исполнительных производствах в базе ФССП",
         "enabled": true
     },
     {


### PR DESCRIPTION
## Description

### Removed

- Source `fssp.base`

### Changed

- Disabled source with name `customs.base`
- Disabled source with name `insurance.dtp`
- Disabled source with name `insurance.dtp.basalt`
- Disabled source with name `insurance.registry`
- Disabled source with name `owner.taxi.history`
- Field `additional_info.vehicle.owner.enforcement_proceedings.has_proceedings` not fillable by `fssp.base` anymore
- Field `tech_data.brand.name.original` not fillable by `customs.base` anymore
- Fields `identifiers.*` not fillable by `customs.base` anymore
- Fields `identifiers_masked.*` not fillable by `customs.base` anymore
- Fields `tech_data.*` not fillable by `customs.base` anymore
- Fields `customs.history.*` not fillable by `customs.base` anymore
- Fields `mileages.items[].*` not fillable by `customs.base` anymore
- Fields `accidents.*` not fillable by `insurance.dtp` anymore
- Fields `accidents.*` not fillable by `insurance.dtp.basalt` anymore
- Fields `accidents.*` not fillable by `insurance.registry` anymore
- Fields `additional_info.vehicle.owner.taxi_history.*` not fillable by `owner.taxi.history` anymore
