### PR TITLE
Remove fines.base.ext source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Source `fines.base.ext`
+
+### Changed
+
+- Field `fines.has_fines` not fillable by `fines.base.ext` anymore
+- Field `fines.date.update` not fillable by `fines.base.ext` anymore
+- Fields `fines.items[].*` not fillable by `fines.base.ext` anymore
+
 ## v4.0.0
 
 ### Changed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -4918,7 +4918,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -4948,7 +4947,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -4965,7 +4963,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -4981,7 +4978,6 @@
         "fillable_by": [
             "fines.base",
             "gibdd.fines",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -4998,7 +4994,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5015,7 +5010,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5058,7 +5052,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.base.dln",
             "fines.base.uin"
         ]
@@ -5073,7 +5066,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5090,7 +5082,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5107,7 +5098,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5123,7 +5113,6 @@
         "fillable_by": [
             "fines.base",
             "gibdd.fines",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5140,7 +5129,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5156,7 +5144,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5172,7 +5159,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5188,7 +5174,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5204,7 +5189,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5220,7 +5204,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5236,7 +5219,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5252,7 +5234,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5269,7 +5250,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5285,7 +5265,6 @@
         "fillable_by": [
             "fines.base",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5302,7 +5281,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5317,7 +5295,6 @@
         ],
         "fillable_by": [
             "fines.base",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",
@@ -5397,8 +5374,7 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.fines",
-            "fines.base.ext"
+            "gibdd.fines"
         ]
     },
     {
@@ -5408,8 +5384,7 @@
             "string"
         ],
         "fillable_by": [
-            "gibdd.fines",
-            "fines.base.ext"
+            "gibdd.fines"
         ]
     },
     {
@@ -5464,7 +5439,6 @@
             "fines.base",
             "gibdd.fines",
             "fines.alt",
-            "fines.base.ext",
             "fines.registry",
             "fines.registry.batch",
             "fines.base.dln",

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -4709,7 +4709,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -4755,7 +4754,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -4775,7 +4773,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -4796,7 +4793,6 @@
                                 "fillable_by": [
                                     "fines.base",
                                     "gibdd.fines",
-                                    "fines.base.ext",
                                     "fines.registry",
                                     "fines.registry.batch",
                                     "fines.base.dln",
@@ -4816,7 +4812,6 @@
                                     "fines.base",
                                     "gibdd.fines",
                                     "fines.alt",
-                                    "fines.base.ext",
                                     "fines.registry",
                                     "fines.registry.batch",
                                     "fines.base.dln",
@@ -4840,7 +4835,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -4905,7 +4899,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.base.dln",
                                             "fines.base.uin"
                                         ]
@@ -4923,7 +4916,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -4950,7 +4942,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -4978,7 +4969,6 @@
                                                     "fines.base",
                                                     "gibdd.fines",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5001,7 +4991,6 @@
                                 "fillable_by": [
                                     "fines.base",
                                     "gibdd.fines",
-                                    "fines.base.ext",
                                     "fines.registry",
                                     "fines.registry.batch",
                                     "fines.base.dln",
@@ -5021,7 +5010,6 @@
                                     "fines.base",
                                     "gibdd.fines",
                                     "fines.alt",
-                                    "fines.base.ext",
                                     "fines.registry",
                                     "fines.registry.batch",
                                     "fines.base.dln",
@@ -5048,7 +5036,6 @@
                                                 "fillable_by": [
                                                     "fines.base",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5067,7 +5054,6 @@
                                                 "fillable_by": [
                                                     "fines.base",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5090,7 +5076,6 @@
                                                 "fillable_by": [
                                                     "fines.base",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5119,7 +5104,6 @@
                                                         "fillable_by": [
                                                             "fines.base",
                                                             "fines.alt",
-                                                            "fines.base.ext",
                                                             "fines.registry",
                                                             "fines.registry.batch",
                                                             "fines.base.dln",
@@ -5140,7 +5124,6 @@
                                                 "fillable_by": [
                                                     "fines.base",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5159,7 +5142,6 @@
                                                 "fillable_by": [
                                                     "fines.base",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5184,7 +5166,6 @@
                                                 "fillable_by": [
                                                     "fines.base",
                                                     "fines.alt",
-                                                    "fines.base.ext",
                                                     "fines.registry",
                                                     "fines.registry.batch",
                                                     "fines.base.dln",
@@ -5206,7 +5187,6 @@
                                             "fines.base",
                                             "gibdd.fines",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -5225,7 +5205,6 @@
                                         "fillable_by": [
                                             "fines.base",
                                             "fines.alt",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -5249,7 +5228,6 @@
                                         ],
                                         "fillable_by": [
                                             "fines.base",
-                                            "fines.base.ext",
                                             "fines.registry",
                                             "fines.registry.batch",
                                             "fines.base.dln",
@@ -5440,8 +5418,7 @@
                                                 "GRZ_PLATE"
                                             ],
                                             "fillable_by": [
-                                                "gibdd.fines",
-                                                "fines.base.ext"
+                                                "gibdd.fines"
                                             ]
                                         },
                                         "uri": {
@@ -5454,8 +5431,7 @@
                                                 "https://via.placeholder.com/300x300.png?text=Test%20GRZ%20Photo"
                                             ],
                                             "fillable_by": [
-                                                "gibdd.fines",
-                                                "fines.base.ext"
+                                                "gibdd.fines"
                                             ]
                                         }
                                     }
@@ -5478,7 +5454,6 @@
                         "fines.base",
                         "gibdd.fines",
                         "fines.alt",
-                        "fines.base.ext",
                         "fines.registry",
                         "fines.registry.batch",
                         "fines.base.dln",
@@ -5505,7 +5480,6 @@
                                 "fines.base",
                                 "gibdd.fines",
                                 "fines.alt",
-                                "fines.base.ext",
                                 "fines.registry",
                                 "fines.registry.batch",
                                 "fines.base.dln",

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -165,11 +165,6 @@
         "enabled": true
     },
     {
-        "name": "fines.base.ext",
-        "description": "Расширенные данные о штрафах, оформленных на ТС",
-        "enabled": true
-    },
-    {
         "name": "rsaosago.base",
         "description": "Информация о всех полисах ОСАГО оформленных на ТC, по данным РСА",
         "enabled": true


### PR DESCRIPTION
## Description

### Removed

- Source `fines.base.ext`

### Changed

- Field `fines.has_fines` not fillable by `fines.base.ext` anymore
- Field `fines.date.update` not fillable by `fines.base.ext` anymore
- Fields `fines.items[].*` not fillable by `fines.base.ext` anymore