### PR TITLE
Draft: Remove pledge and eaisto basalt sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Source `eaisto.basalt`
+- Source `pledge.online`
+- Fields `identifiers.*` not fillable by `eaisto.basalt` anymore
+- Fields `identifiers_masked.*` not fillable by `eaisto.basalt` anymore
+- Fields `diagnostic_cards.*` not fillable by `eaisto.basalt` anymore
+- Fields `mileages.*` not fillable by `eaisto.basalt` anymore
+- Fields `pledges_online.*` not fillable by `pledge.online` anymore
+
 ## v4.2.0
 
 ### Added

--- a/__tests__/Makefile
+++ b/__tests__/Makefile
@@ -17,7 +17,7 @@ install: ## Install all dependencies
 	docker-compose run $(RUN_ARGS) node yarn install
 
 test: ## Execute tests
-	docker-compose run $(RUN_ARGS) node yarn test
+	docker compose run $(RUN_ARGS) node yarn test
 
 shell: ## Start shell into container with node
 	docker-compose run $(RUN_ARGS) node sh

--- a/__tests__/Makefile
+++ b/__tests__/Makefile
@@ -14,10 +14,10 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 install: ## Install all dependencies
-	docker-compose run $(RUN_ARGS) node yarn install
+	docker compose run $(RUN_ARGS) node yarn install
 
 test: ## Execute tests
 	docker compose run $(RUN_ARGS) node yarn test
 
 shell: ## Start shell into container with node
-	docker-compose run $(RUN_ARGS) node sh
+	docker compose run $(RUN_ARGS) node sh

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -12,7 +12,6 @@
             "regactions.registry",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -26,7 +25,6 @@
             "base",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -67,7 +65,6 @@
             "regactions.registry",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -82,7 +79,6 @@
             "base.basalt",
             "regactions.registry",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -99,7 +95,6 @@
             "regactions.registry",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -113,7 +108,6 @@
             "base",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -154,7 +148,6 @@
             "regactions.registry",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -169,7 +162,6 @@
             "regactions.registry",
             "base.basalt",
             "eaisto.registry",
-            "eaisto.basalt",
             "gibdd.history.registry"
         ]
     },
@@ -1524,8 +1516,7 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "eaisto.registry",
-            "eaisto.basalt"
+            "eaisto.registry"
         ]
     },
     {
@@ -1536,8 +1527,7 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "eaisto.registry",
-            "eaisto.basalt"
+            "eaisto.registry"
         ]
     },
     {
@@ -1559,8 +1549,7 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "eaisto.registry",
-            "eaisto.basalt"
+            "eaisto.registry"
         ]
     },
     {
@@ -1571,8 +1560,7 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "eaisto.registry",
-            "eaisto.basalt"
+            "eaisto.registry"
         ]
     },
     {
@@ -1594,8 +1582,7 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "eaisto.registry",
-            "eaisto.basalt"
+            "eaisto.registry"
         ]
     },
     {
@@ -1606,8 +1593,7 @@
         ],
         "fillable_by": [
             "eaisto.registry",
-            "gibdd.eaisto",
-            "eaisto.basalt"
+            "gibdd.eaisto"
         ]
     },
     {
@@ -1618,8 +1604,7 @@
         ],
         "fillable_by": [
             "gibdd.eaisto",
-            "eaisto.registry",
-            "eaisto.basalt"
+            "eaisto.registry"
         ]
     },
     {
@@ -3911,9 +3896,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].number",
@@ -3921,9 +3904,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].type",
@@ -3931,9 +3912,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].pledgors[].name",
@@ -3941,9 +3920,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].pledgors[].type",
@@ -3951,9 +3928,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].pledgors[].dob",
@@ -3961,9 +3936,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].pledgees[].name",
@@ -3971,9 +3944,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].pledgees[].type",
@@ -3981,9 +3952,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.items[].pledgees[].dob",
@@ -3991,9 +3960,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.date.update",
@@ -4001,9 +3968,7 @@
         "types": [
             "string"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_online.in_pledge",
@@ -4011,9 +3976,7 @@
         "types": [
             "boolean"
         ],
-        "fillable_by": [
-            "pledge.online"
-        ]
+        "fillable_by": []
     },
     {
         "path": "pledges_nbki.items[].date.end",
@@ -5461,7 +5424,6 @@
             "service.history.filter",
             "service.history.wilgood",
             "eaisto.registry",
-            "eaisto.basalt",
             "repairs.history.registry"
         ]
     },
@@ -5481,7 +5443,6 @@
             "service.history.filter",
             "service.history.wilgood",
             "eaisto.registry",
-            "eaisto.basalt",
             "repairs.history.registry"
         ]
     },
@@ -5509,7 +5470,6 @@
             "service.history.filter",
             "service.history.wilgood",
             "eaisto.registry",
-            "eaisto.basalt",
             "repairs.history.registry"
         ]
     },

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -360,7 +360,6 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         },
@@ -384,7 +383,6 @@
                                 "base",
                                 "base.basalt",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         },
@@ -455,7 +453,6 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         },
@@ -480,7 +477,6 @@
                                 "regactions.registry",
                                 "base.basalt",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         }
@@ -517,7 +513,6 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         },
@@ -538,7 +533,6 @@
                                 "base",
                                 "base.basalt",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         },
@@ -600,7 +594,6 @@
                                 "base.basalt",
                                 "regactions.registry",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         },
@@ -622,7 +615,6 @@
                                 "regactions.registry",
                                 "base.basalt",
                                 "eaisto.registry",
-                                "eaisto.basalt",
                                 "gibdd.history.registry"
                             ]
                         }
@@ -7358,9 +7350,7 @@
                                         "examples": [
                                             "2024-05-30 00:00:00"
                                         ],
-                                        "fillable_by": [
-                                            "pledge.online"
-                                        ]
+                                        "fillable_by": []
                                     }
                                 }
                             },
@@ -7373,9 +7363,7 @@
                                 "examples": [
                                     "2024-001-406288-623\/241"
                                 ],
-                                "fillable_by": [
-                                    "pledge.online"
-                                ]
+                                "fillable_by": []
                             },
                             "pledgors": {
                                 "type": "array",
@@ -7400,9 +7388,7 @@
                                                 "Евгений Сергеевич Дроздов",
                                                 "REFUSE"
                                             ],
-                                            "fillable_by": [
-                                                "pledge.online"
-                                            ]
+                                            "fillable_by": []
                                         },
                                         "type": {
                                             "description": "Тип залогодателя",
@@ -7418,9 +7404,7 @@
                                             "examples": [
                                                 "PERSON"
                                             ],
-                                            "fillable_by": [
-                                                "pledge.online"
-                                            ]
+                                            "fillable_by": []
                                         },
                                         "dob": {
                                             "description": "Дата рождения залогодателя",
@@ -7435,9 +7419,7 @@
                                             "examples": [
                                                 "1973-08-31"
                                             ],
-                                            "fillable_by": [
-                                                "pledge.online"
-                                            ]
+                                            "fillable_by": []
                                         }
                                     }
                                 }
@@ -7465,9 +7447,7 @@
                                                 "ПАО ГлавСвет",
                                                 "REFUSE"
                                             ],
-                                            "fillable_by": [
-                                                "pledge.online"
-                                            ]
+                                            "fillable_by": []
                                         },
                                         "type": {
                                             "description": "Тип залогодержателя",
@@ -7483,9 +7463,7 @@
                                             "examples": [
                                                 "LEGAL"
                                             ],
-                                            "fillable_by": [
-                                                "pledge.online"
-                                            ]
+                                            "fillable_by": []
                                         },
                                         "dob": {
                                             "description": "Дата рождения залогодержателя",
@@ -7500,9 +7478,7 @@
                                             "examples": [
                                                 null
                                             ],
-                                            "fillable_by": [
-                                                "pledge.online"
-                                            ]
+                                            "fillable_by": []
                                         }
                                     }
                                 }
@@ -7516,9 +7492,7 @@
                                 "examples": [
                                     "Возникновение"
                                 ],
-                                "fillable_by": [
-                                    "pledge.online"
-                                ]
+                                "fillable_by": []
                             }
                         }
                     }
@@ -7539,9 +7513,7 @@
                             "examples": [
                                 "2019-10-17 00:20:00"
                             ],
-                            "fillable_by": [
-                                "pledge.online"
-                            ]
+                            "fillable_by": []
                         }
                     }
                 },
@@ -7560,9 +7532,7 @@
                         true,
                         null
                     ],
-                    "fillable_by": [
-                        "pledge.online"
-                    ]
+                    "fillable_by": []
                 }
             }
         },
@@ -11044,7 +11014,6 @@
                                             "service.history.filter",
                                             "service.history.wilgood",
                                             "eaisto.registry",
-                                            "eaisto.basalt",
                                             "repairs.history.registry"
                                         ]
                                     }
@@ -11070,7 +11039,6 @@
                                     "service.history.filter",
                                     "service.history.wilgood",
                                     "eaisto.registry",
-                                    "eaisto.basalt",
                                     "repairs.history.registry"
                                 ]
                             },
@@ -11094,7 +11062,6 @@
                                             "service.history.filter",
                                             "service.history.wilgood",
                                             "eaisto.registry",
-                                            "eaisto.basalt",
                                             "customs.base",
                                             null
                                         ],
@@ -11132,7 +11099,6 @@
                                             "service.history.filter",
                                             "service.history.wilgood",
                                             "eaisto.registry",
-                                            "eaisto.basalt",
                                             "repairs.history.registry"
                                         ]
                                     }
@@ -11178,8 +11144,7 @@
                                         ],
                                         "fillable_by": [
                                             "gibdd.eaisto",
-                                            "eaisto.registry",
-                                            "eaisto.basalt"
+                                            "eaisto.registry"
                                         ]
                                     },
                                     "to": {
@@ -11197,8 +11162,7 @@
                                         ],
                                         "fillable_by": [
                                             "gibdd.eaisto",
-                                            "eaisto.registry",
-                                            "eaisto.basalt"
+                                            "eaisto.registry"
                                         ]
                                     }
                                 }
@@ -11232,8 +11196,7 @@
                                         ],
                                         "fillable_by": [
                                             "gibdd.eaisto",
-                                            "eaisto.registry",
-                                            "eaisto.basalt"
+                                            "eaisto.registry"
                                         ]
                                     },
                                     "type": {
@@ -11247,8 +11210,7 @@
                                         ],
                                         "fillable_by": [
                                             "gibdd.eaisto",
-                                            "eaisto.registry",
-                                            "eaisto.basalt"
+                                            "eaisto.registry"
                                         ]
                                     }
                                 }
@@ -11288,8 +11250,7 @@
                                 ],
                                 "fillable_by": [
                                     "gibdd.eaisto",
-                                    "eaisto.registry",
-                                    "eaisto.basalt"
+                                    "eaisto.registry"
                                 ]
                             },
                             "actuality": {
@@ -11311,8 +11272,7 @@
                                         ],
                                         "fillable_by": [
                                             "eaisto.registry",
-                                            "gibdd.eaisto",
-                                            "eaisto.basalt"
+                                            "gibdd.eaisto"
                                         ]
                                     }
                                 }
@@ -11338,8 +11298,7 @@
                             ],
                             "fillable_by": [
                                 "gibdd.eaisto",
-                                "eaisto.registry",
-                                "eaisto.basalt"
+                                "eaisto.registry"
                             ]
                         }
                     }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -220,11 +220,6 @@
         "enabled": true
     },
     {
-        "name": "eaisto.basalt",
-        "description": "Диагностические карты (ЕАИСТО)",
-        "enabled": true
-    },
-    {
         "name": "driver.mileages",
         "description": "Среднегодовой пробег по водителю",
         "enabled": true
@@ -307,11 +302,6 @@
     {
         "name": "insurance.event.probability.score",
         "description": "Страховые скоринги: Частота страхового случая",
-        "enabled": true
-    },
-    {
-        "name": "pledge.online",
-        "description": "Данные о нахождении ТС в залоге Онлайн",
         "enabled": true
     },
     {


### PR DESCRIPTION
## Description

### Removed

- Source `eaisto.basalt`
- Source `pledge.online`
- Fields `identifiers.*` not fillable by `eaisto.basalt` anymore
- Fields `identifiers_masked.*` not fillable by `eaisto.basalt` anymore
- Fields `diagnostic_cards.*` not fillable by `eaisto.basalt` anymore
- Fields `mileages.*` not fillable by `eaisto.basalt` anymore
- Fields `pledges_online.*` not fillable by `pledge.online` anymore