### PR TITLE
Remove fields from additional info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Field with path `additional_info.vehicle.passport.date.receive`
+- Fields with path `additional_info.vehicle.owner.geo.*`
+
 ## v5.1.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -784,17 +784,6 @@
         "fillable_by": []
     },
     {
-        "path": "additional_info.vehicle.owner.geo",
-        "description": "Дополнительная информация: Гео-данные владельца (техники)",
-        "types": [
-            "object"
-        ],
-        "fillable_by": [
-            "base",
-            "regactions.registry"
-        ]
-    },
-    {
         "path": "additional_info.vehicle.owner.taxi_history.probable_taxi_driver",
         "description": "История владельца в такси: Возможная работа в такси",
         "types": [
@@ -881,16 +870,6 @@
             "string"
         ],
         "fillable_by": []
-    },
-    {
-        "path": "additional_info.vehicle.passport.date.receive",
-        "description": "Дополнительная информация: Дата выдачи паспорта ТС",
-        "types": [
-            "string"
-        ],
-        "fillable_by": [
-            "base"
-        ]
     },
     {
         "path": "additional_info.vehicle.passport.has_dublicate",

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -148,14 +148,6 @@
                 "enforcement_proceedings": {
                     "has_proceedings": null
                 },
-                "geo": {
-                    "country": null,
-                    "region": null,
-                    "city": null,
-                    "street": null,
-                    "house": null,
-                    "postal_code": null
-                },
                 "taxi_history": {
                     "probable_taxi_driver": null,
                     "taxi_licenses": {
@@ -189,9 +181,6 @@
                 }
             },
             "passport": {
-                "date": {
-                    "receive": null
-                },
                 "has_dublicate": null,
                 "number": null,
                 "type": null,

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -148,14 +148,6 @@
                 "enforcement_proceedings": {
                     "has_proceedings": true
                 },
-                "geo": {
-                    "country": null,
-                    "region": "Пензенская",
-                    "city": "Пушкино",
-                    "street": null,
-                    "house": null,
-                    "postal_code": "141207"
-                },
                 "taxi_history": {
                     "probable_taxi_driver": true,
                     "taxi_licenses": {
@@ -189,9 +181,6 @@
                 }
             },
             "passport": {
-                "date": {
-                    "receive": "2018-08-05 00:00:00"
-                },
                 "has_dublicate": false,
                 "number": "8047307033",
                 "type": "Электронный паспорт транспортного средства",

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -1731,50 +1731,6 @@
                                         }
                                     }
                                 },
-                                "geo": {
-                                    "description": "Гео-данные владельца (техники)",
-                                    "oneOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "allOf": [
-                                                {
-                                                    "$ref": "#/definitions/geo_raw_data"
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "postal_code": {
-                                                            "description": "Почтовый индекс",
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "null"
-                                                                },
-                                                                {
-                                                                    "type": "string",
-                                                                    "pattern": "^[0-9]+$",
-                                                                    "minLength": 6,
-                                                                    "maxLength": 6
-                                                                }
-                                                            ],
-                                                            "examples": [
-                                                                "141207",
-                                                                null
-                                                            ],
-                                                            "fillable_by": [
-                                                                "base"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "fillable_by": [
-                                        "base",
-                                        "regactions.registry"
-                                    ]
-                                },
                                 "taxi_history": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -1968,29 +1924,6 @@
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
-                                "date": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "receive": {
-                                            "description": "Дата выдачи паспорта ТС",
-                                            "oneOf": [
-                                                {
-                                                    "type": "null"
-                                                },
-                                                {
-                                                    "$ref": "#/definitions/datetime"
-                                                }
-                                            ],
-                                            "examples": [
-                                                "2018-08-05 00:00:00"
-                                            ],
-                                            "fillable_by": [
-                                                "base"
-                                            ]
-                                        }
-                                    }
-                                },
                                 "has_dublicate": {
                                     "description": "Была ли замена ПТС?",
                                     "type": [


### PR DESCRIPTION
## Description

### Removed

- Field with path `additional_info.vehicle.passport.date.receive`
- Fields with path `additional_info.vehicle.owner.geo.*`
