### PR TITLE
Add elpts.online source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Source `elpts.online`
+
+### Changed
+
+- Field with path `identifiers.vehicle.pts` also fillable by `elpts.online`
+- Field with path `identifiers_masked.vehicle.pts` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.passport.number` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.passport.type` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.passport.status` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.utilization_tax` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.customs_registration` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.restriction.customs` also fillable by `elpts.online`
+- Field with path `additional_info.vehicle.restriction.other` also fillable by `elpts.online`
+
 ## v5.2.0
 
 ### Removed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -38,7 +38,8 @@
             "base",
             "gibdd.history",
             "base.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "elpts.online"
         ]
     },
     {
@@ -109,7 +110,8 @@
             "base",
             "gibdd.history",
             "base.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "elpts.online"
         ]
     },
     {
@@ -891,7 +893,8 @@
             "gibdd.history",
             "base",
             "base.basalt",
-            "gibdd.history.registry"
+            "gibdd.history.registry",
+            "elpts.online"
         ]
     },
     {
@@ -900,7 +903,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "elpts.online"
+        ]
     },
     {
         "path": "additional_info.vehicle.passport.status",
@@ -908,7 +913,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "elpts.online"
+        ]
     },
     {
         "path": "additional_info.vehicle.techreglament_category.code",
@@ -1354,7 +1361,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "elpts.online"
+        ]
     },
     {
         "path": "additional_info.vehicle.customs_registration",
@@ -1362,7 +1371,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "elpts.online"
+        ]
     },
     {
         "path": "additional_info.vehicle.restriction.customs",
@@ -1370,7 +1381,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "elpts.online"
+        ]
     },
     {
         "path": "additional_info.vehicle.restriction.other",
@@ -1378,7 +1391,9 @@
         "types": [
             "string"
         ],
-        "fillable_by": []
+        "fillable_by": [
+            "elpts.online"
+        ]
     },
     {
         "path": "additional_info.driver.mileages.average_annual.value",

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -406,7 +406,8 @@
                                 "base",
                                 "base.basalt",
                                 "gibdd.history",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "elpts.online"
                             ]
                         },
                         "body": {
@@ -531,7 +532,8 @@
                                 "base",
                                 "base.basalt",
                                 "gibdd.history",
-                                "gibdd.history.registry"
+                                "gibdd.history.registry",
+                                "elpts.online"
                             ]
                         },
                         "body": {
@@ -1954,7 +1956,8 @@
                                         "gibdd.history",
                                         "base",
                                         "base.basalt",
-                                        "gibdd.history.registry"
+                                        "gibdd.history.registry",
+                                        "elpts.online"
                                     ]
                                 },
                                 "type": {
@@ -1966,7 +1969,9 @@
                                     "examples": [
                                         "Электронный паспорт транспортного средства"
                                     ],
-                                    "fillable_by": []
+                                    "fillable_by": [
+                                        "elpts.online"
+                                    ]
                                 },
                                 "status": {
                                     "description": "Статус паспорта ТС",
@@ -1977,7 +1982,9 @@
                                     "examples": [
                                         "действующий"
                                     ],
-                                    "fillable_by": []
+                                    "fillable_by": [
+                                        "elpts.online"
+                                    ]
                                 }
                             }
                         },
@@ -2060,7 +2067,9 @@
                             "examples": [
                                 "РФ уплачен"
                             ],
-                            "fillable_by": []
+                            "fillable_by": [
+                                "elpts.online"
+                            ]
                         },
                         "customs_registration": {
                             "description": "Сведения о выпуске (таможенное оформление)",
@@ -2071,7 +2080,9 @@
                             "examples": [
                                 "Отсутствуют"
                             ],
-                            "fillable_by": []
+                            "fillable_by": [
+                                "elpts.online"
+                            ]
                         },
                         "restriction": {
                             "type": "object",
@@ -2086,7 +2097,9 @@
                                     "examples": [
                                         "Отсутствуют"
                                     ],
-                                    "fillable_by": []
+                                    "fillable_by": [
+                                        "elpts.online"
+                                    ]
                                 },
                                 "other": {
                                     "description": "Ограничения (обременения) за исключением таможенных",
@@ -2097,7 +2110,9 @@
                                     "examples": [
                                         "Отсутствуют"
                                     ],
-                                    "fillable_by": []
+                                    "fillable_by": [
+                                        "elpts.online"
+                                    ]
                                 }
                             }
                         },

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -313,5 +313,10 @@
         "name": "new.vehicle.price",
         "description": "Рыночная стоимость нового ТС",
         "enabled": true
+    },
+    {
+        "name": "elpts.online",
+        "description": "Данные по ЭПТС",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
## Description

### Added

- Source `elpts.online`

### Changed

- Field with path `identifiers.vehicle.pts` also fillable by `elpts.online`
- Field with path `identifiers_masked.vehicle.pts` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.passport.number` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.passport.type` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.passport.status` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.utilization_tax` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.customs_registration` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.restriction.customs` also fillable by `elpts.online`
- Field with path `additional_info.vehicle.restriction.other` also fillable by `elpts.online`