### PR TITLE
Add brand and model fillable fields for images.archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Field with path `images.photos.items[].vehicle.brand.name` also fillable by `images.archive`
+- Field with path `images.photos.items[].vehicle.model.name` also fillable by `images.archive`
+
 ## v5.3.0
 
 ### Changed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -5248,7 +5248,8 @@
             "string"
         ],
         "fillable_by": [
-            "images.avtonomer"
+            "images.avtonomer",
+            "images.archive"
         ]
     },
     {
@@ -5258,7 +5259,8 @@
             "string"
         ],
         "fillable_by": [
-            "images.avtonomer"
+            "images.avtonomer",
+            "images.archive"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -10998,7 +10998,8 @@
                                                             "OPEL"
                                                         ],
                                                         "fillable_by": [
-                                                            "images.avtonomer"
+                                                            "images.avtonomer",
+                                                            "images.archive"
                                                         ]
                                                     }
                                                 }
@@ -11017,7 +11018,8 @@
                                                             "MONTEREY"
                                                         ],
                                                         "fillable_by": [
-                                                            "images.avtonomer"
+                                                            "images.avtonomer",
+                                                            "images.archive"
                                                         ]
                                                     }
                                                 }


### PR DESCRIPTION
## Description

### Changed

- Field with path `images.photos.items[].vehicle.brand.name` also fillable by `images.archive`
- Field with path `images.photos.items[].vehicle.model.name` also fillable by `images.archive`
