### PR TITLE
Add autobase.repairs.history.registry source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
+- Source `autobase.repairs.history.registry`
+- Fields with path `repairs.history.*` also fillable by `autobase.repairs.history.registry`
+- Fields with path `mileages.*` also fillable by `autobase.repairs.history.registry`
+
 ## v5.14.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
 ## v5.14.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -5239,7 +5239,8 @@
             "service.history.filter",
             "service.history.wilgood",
             "eaisto.registry",
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5258,7 +5259,8 @@
             "service.history.filter",
             "service.history.wilgood",
             "eaisto.registry",
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5285,7 +5287,8 @@
             "service.history.filter",
             "service.history.wilgood",
             "eaisto.registry",
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5775,7 +5778,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5793,7 +5797,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5803,7 +5808,8 @@
             "integer"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5813,7 +5819,8 @@
             "integer"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5823,7 +5830,8 @@
             "integer"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5833,7 +5841,8 @@
             "integer"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5843,7 +5852,8 @@
             "integer"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5853,7 +5863,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5863,7 +5874,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5873,7 +5885,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5903,7 +5916,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5933,7 +5947,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5963,7 +5978,8 @@
             "integer"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {
@@ -5973,7 +5989,8 @@
             "string"
         ],
         "fillable_by": [
-            "repairs.history.registry"
+            "repairs.history.registry",
+            "autobase.repairs.history.registry"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -2957,7 +2957,8 @@
                                                     "084/08/617"
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             },
                                             "claim": {
@@ -2991,7 +2992,8 @@
                                                     "2010-12-17"
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             }
                                         }
@@ -3007,7 +3009,8 @@
                                             54900
                                         ],
                                         "fillable_by": [
-                                            "repairs.history.registry"
+                                            "repairs.history.registry",
+                                            "autobase.repairs.history.registry"
                                         ]
                                     },
                                     "cost": {
@@ -3025,7 +3028,8 @@
                                                     395280
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             },
                                             "labour": {
@@ -3039,7 +3043,8 @@
                                                     45910
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             },
                                             "parts": {
@@ -3053,7 +3058,8 @@
                                                     339670
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             },
                                             "paint": {
@@ -3067,7 +3073,8 @@
                                                     9700
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             }
                                         }
@@ -3086,7 +3093,8 @@
                                                     "OPEL [V] [61] [R]"
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             },
                                             "model": {
@@ -3099,7 +3107,8 @@
                                                     "MONTEREY [V] [XA] [S] [36] [M]"
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             },
                                             "sub_model": {
@@ -3112,7 +3121,8 @@
                                                     "Monterey"
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ]
                                             }
                                         }
@@ -3172,7 +3182,8 @@
                                             "KASKO"
                                         ],
                                         "fillable_by": [
-                                            "repairs.history.registry"
+                                            "repairs.history.registry",
+                                            "autobase.repairs.history.registry"
                                         ]
                                     },
                                     "repairer": {
@@ -3241,7 +3252,8 @@
                                                                 "Запасная часть для частичной замены"
                                                             ],
                                                             "fillable_by": [
-                                                                "repairs.history.registry"
+                                                                "repairs.history.registry",
+                                                                "autobase.repairs.history.registry"
                                                             ]
                                                         },
                                                         "repair": {
@@ -3289,7 +3301,8 @@
                                                     "null"
                                                 ],
                                                 "fillable_by": [
-                                                    "repairs.history.registry"
+                                                    "repairs.history.registry",
+                                                    "autobase.repairs.history.registry"
                                                 ],
                                                 "examples": [
                                                     0,
@@ -3318,7 +3331,8 @@
                                         "2021-01-11 12:54:00"
                                     ],
                                     "fillable_by": [
-                                        "repairs.history.registry"
+                                        "repairs.history.registry",
+                                        "autobase.repairs.history.registry"
                                     ]
                                 }
                             }
@@ -10619,7 +10633,8 @@
                                             "service.history.filter",
                                             "service.history.wilgood",
                                             "eaisto.registry",
-                                            "repairs.history.registry"
+                                            "repairs.history.registry",
+                                            "autobase.repairs.history.registry"
                                         ]
                                     }
                                 }
@@ -10644,7 +10659,8 @@
                                     "service.history.filter",
                                     "service.history.wilgood",
                                     "eaisto.registry",
-                                    "repairs.history.registry"
+                                    "repairs.history.registry",
+                                    "autobase.repairs.history.registry"
                                 ]
                             },
                             "filled_by": {
@@ -10668,6 +10684,7 @@
                                             "service.history.wilgood",
                                             "eaisto.registry",
                                             "customs.base",
+                                            "autobase.repairs.history.registry",
                                             null
                                         ],
                                         "examples": [
@@ -10704,7 +10721,8 @@
                                             "service.history.filter",
                                             "service.history.wilgood",
                                             "eaisto.registry",
-                                            "repairs.history.registry"
+                                            "repairs.history.registry",
+                                            "autobase.repairs.history.registry"
                                         ]
                                     }
                                 }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -323,5 +323,10 @@
         "name": "insurance.antifraud.probability.score",
         "description": "Предстраховой антифрод",
         "enabled": true
+    },
+    {
+        "name": "autobase.repairs.history.registry",
+        "description": "Реестр истории ремонтных работ (Автобаза)",
+        "enabled": true
     }
 ]


### PR DESCRIPTION
## Description

### Added

- Source `autobase.repairs.history.registry`
- Fields with path `repairs.history.*` also fillable by `autobase.repairs.history.registry`
- Fields with path `mileages.*` also fillable by `autobase.repairs.history.registry`
