### PR TITLE
Fix base.granit fillable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Field `identifiers.vehicle.reg_num` not fillable by `base.granit`
+- Field `identifiers.vehicle.pts` not fillable by `base.granit`
+- Field `identifiers.vehicle.chassis` not fillable by `base.granit`
+- Field `identifiers_masked.vehicle.reg_num` not fillable by `base.granit`
+- Field `identifiers_masked.vehicle.pts` not fillable by `base.granit`
+- Field `identifiers_masked.vehicle.chassis` not fillable by `base.granit`
+- Field `tech_data.engine.model.name` not fillable by `base.granit`
+- Field `additional_info.vehicle.passport.number` not fillable by `base.granit`
+
 ## v5.21.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -25,7 +25,6 @@
         "fillable_by": [
             "base",
             "base.basalt",
-            "base.granit",
             "eaisto.registry",
             "gibdd.history.registry"
         ]
@@ -40,7 +39,6 @@
             "base",
             "gibdd.history",
             "base.basalt",
-            "base.granit",
             "gibdd.history.registry",
             "elpts.online"
         ]
@@ -70,7 +68,6 @@
         "fillable_by": [
             "base",
             "base.basalt",
-            "base.granit",
             "regactions.registry",
             "eaisto.registry",
             "gibdd.history.registry"
@@ -102,7 +99,6 @@
         "fillable_by": [
             "base",
             "base.basalt",
-            "base.granit",
             "eaisto.registry",
             "gibdd.history.registry"
         ]
@@ -117,7 +113,6 @@
             "base",
             "gibdd.history",
             "base.basalt",
-            "base.granit",
             "gibdd.history.registry",
             "elpts.online"
         ]
@@ -148,7 +143,6 @@
             "base",
             "regactions.registry",
             "base.basalt",
-            "base.granit",
             "eaisto.registry",
             "gibdd.history.registry"
         ]
@@ -418,7 +412,6 @@
         "fillable_by": [
             "base",
             "base.basalt",
-            "base.granit",
             "gibdd.history.registry"
         ]
     },
@@ -930,7 +923,6 @@
             "gibdd.history",
             "base",
             "base.basalt",
-            "base.granit",
             "gibdd.history.registry",
             "elpts.online"
         ]

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -383,7 +383,6 @@
                             "fillable_by": [
                                 "base",
                                 "base.basalt",
-                                "base.granit",
                                 "eaisto.registry",
                                 "gibdd.history.registry"
                             ]
@@ -407,7 +406,6 @@
                             "fillable_by": [
                                 "base",
                                 "base.basalt",
-                                "base.granit",
                                 "gibdd.history",
                                 "gibdd.history.registry",
                                 "elpts.online"
@@ -459,7 +457,6 @@
                                 "base",
                                 "regactions.registry",
                                 "base.basalt",
-                                "base.granit",
                                 "eaisto.registry",
                                 "gibdd.history.registry"
                             ]
@@ -517,7 +514,6 @@
                             "fillable_by": [
                                 "base",
                                 "base.basalt",
-                                "base.granit",
                                 "eaisto.registry",
                                 "gibdd.history.registry"
                             ]
@@ -538,7 +534,6 @@
                             "fillable_by": [
                                 "base",
                                 "base.basalt",
-                                "base.granit",
                                 "gibdd.history",
                                 "gibdd.history.registry",
                                 "elpts.online"
@@ -584,7 +579,6 @@
                                 "base",
                                 "regactions.registry",
                                 "base.basalt",
-                                "base.granit",
                                 "eaisto.registry",
                                 "gibdd.history.registry"
                             ]
@@ -1036,7 +1030,6 @@
                                     "fillable_by": [
                                         "base",
                                         "base.basalt",
-                                        "base.granit",
                                         "gibdd.history.registry"
                                     ]
                                 }
@@ -1993,7 +1986,6 @@
                                         "gibdd.history",
                                         "base",
                                         "base.basalt",
-                                        "base.granit",
                                         "gibdd.history.registry",
                                         "elpts.online"
                                     ]


### PR DESCRIPTION
### Removed

- Field `identifiers.vehicle.reg_num` not fillable by `base.granit`
- Field `identifiers.vehicle.pts` not fillable by `base.granit`
- Field `identifiers.vehicle.chassis` not fillable by `base.granit`
- Field `identifiers_masked.vehicle.reg_num` not fillable by `base.granit`
- Field `identifiers_masked.vehicle.pts` not fillable by `base.granit`
- Field `identifiers_masked.vehicle.chassis` not fillable by `base.granit`
- Field `tech_data.engine.model.name` not fillable by `base.granit`
- Field `additional_info.vehicle.passport.number` not fillable by `base.granit`