### PR TITLE
Remove incorrect `is_multi_pledgor` fields from `pledge_pledgors.items`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Field with path `pledge_pledgors.items[].pledgors[].is_multi_pledgor`
+- Field with path `pledge_pledgors.items[].pledgees[].is_multi_pledgor`
+
 ## v5.26.0
 
 ### Added

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -8935,16 +8935,6 @@
         ]
     },
     {
-        "path": "pledge_pledgors.items[].pledgors[].is_multi_pledgor",
-        "description": "Одновременные залоги: Залогодатель, является ли наборщиком",
-        "types": [
-            "boolean"
-        ],
-        "fillable_by": [
-            "pledgors.registry"
-        ]
-    },
-    {
         "path": "pledge_pledgors.items[].pledgees[].name",
         "description": "Одновременные залоги: Залогодержатель, ФИО/название",
         "types": [
@@ -8979,16 +8969,6 @@
         "description": "Одновременные залоги: Залогодержатель, ИНН",
         "types": [
             "string"
-        ],
-        "fillable_by": [
-            "pledgors.registry"
-        ]
-    },
-    {
-        "path": "pledge_pledgors.items[].pledgees[].is_multi_pledgor",
-        "description": "Одновременные залоги: Залогодержатель, является ли наборщиком",
-        "types": [
-            "boolean"
         ],
         "fillable_by": [
             "pledgors.registry"

--- a/reports/default/examples/empty.json
+++ b/reports/default/examples/empty.json
@@ -933,8 +933,7 @@
                         "name": null,
                         "type": null,
                         "dob": null,
-                        "tin": null,
-                        "is_multi_pledgor": null
+                        "tin": null
                     }
                 ],
                 "pledgees": [
@@ -942,8 +941,7 @@
                         "name": null,
                         "type": null,
                         "dob": null,
-                        "tin": null,
-                        "is_multi_pledgor": null
+                        "tin": null
                     }
                 ],
                 "vehicle": [

--- a/reports/default/examples/full.json
+++ b/reports/default/examples/full.json
@@ -1195,8 +1195,7 @@
                         "name": "К Е Б*****",
                         "type": "person",
                         "dob": "195*******",
-                        "tin": null,
-                        "is_multi_pledgor": false
+                        "tin": null
                     }
                 ],
                 "pledgees": [
@@ -1204,8 +1203,7 @@
                         "name": "Общество с ограниченной ответственностью \"Русфинанс банк\"",
                         "type": "org",
                         "dob": null,
-                        "tin": "5012003647",
-                        "is_multi_pledgor": null
+                        "tin": "5012003647"
                     }
                 ],
                 "vehicle": [

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -7424,16 +7424,6 @@
                                             "fillable_by": [
                                                 "pledgors.registry"
                                             ]
-                                        },
-                                        "is_multi_pledgor": {
-                                            "description": "Залогодатель, является ли наборщиком",
-                                            "type": [
-                                                "boolean",
-                                                "null"
-                                            ],
-                                            "fillable_by": [
-                                                "pledgors.registry"
-                                            ]
                                         }
                                     }
                                 }
@@ -7478,16 +7468,6 @@
                                             "description": "Залогодержатель, ИНН",
                                             "type": [
                                                 "string",
-                                                "null"
-                                            ],
-                                            "fillable_by": [
-                                                "pledgors.registry"
-                                            ]
-                                        },
-                                        "is_multi_pledgor": {
-                                            "description": "Залогодержатель, является ли наборщиком",
-                                            "type": [
-                                                "boolean",
                                                 "null"
                                             ],
                                             "fillable_by": [


### PR DESCRIPTION
## Description

Remove incorrect `is_multi_pledgor` fields from `pledge_pledgors.items`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Removed

- Field with path `pledge_pledgors.items[].pledgors[].is_multi_pledgor`
- Field with path `pledge_pledgors.items[].pledgees[].is_multi_pledgor`
