### PR TITLE
Add `wanted.restrict.basalt` source to stealings and restrictions fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Source `wanted.restrict.basalt`
+- Field with path `stealings.is_wanted` also fillable by `wanted.restrict.basalt`
+- Field with path `stealings.date.update` also fillable by `wanted.restrict.basalt`
+- Field with path `restrictions.registration_actions.date.update` also fillable by `wanted.restrict.basalt`
+- Field with path `restrictions.registration_actions.has_restrictions` also fillable by `wanted.restrict.basalt`
+
 ## v5.27.0
 
 ### Removed

--- a/fields/default/fields_list.json
+++ b/fields/default/fields_list.json
@@ -4121,7 +4121,8 @@
             "gibdd.wanted",
             "gibdd.wanted.registry",
             "base.basalt",
-            "base.granit"
+            "base.granit",
+            "wanted.restrict.basalt"
         ]
     },
     {
@@ -4134,7 +4135,8 @@
             "gibdd.wanted",
             "gibdd.wanted.registry",
             "base.basalt",
-            "base.granit"
+            "base.granit",
+            "wanted.restrict.basalt"
         ]
     },
     {
@@ -4192,7 +4194,8 @@
         "fillable_by": [
             "gibdd.restrict",
             "base.basalt",
-            "base.granit"
+            "base.granit",
+            "wanted.restrict.basalt"
         ]
     },
     {
@@ -4351,7 +4354,8 @@
         "fillable_by": [
             "gibdd.restrict",
             "base.basalt",
-            "base.granit"
+            "base.granit",
+            "wanted.restrict.basalt"
         ]
     },
     {

--- a/reports/default/json-schema.json
+++ b/reports/default/json-schema.json
@@ -12052,7 +12052,8 @@
                                     "fillable_by": [
                                         "gibdd.restrict",
                                         "base.basalt",
-                                        "base.granit"
+                                        "base.granit",
+                                        "wanted.restrict.basalt"
                                     ]
                                 }
                             }
@@ -12329,7 +12330,8 @@
                             "fillable_by": [
                                 "gibdd.restrict",
                                 "base.basalt",
-                                "base.granit"
+                                "base.granit",
+                                "wanted.restrict.basalt"
                             ]
                         }
                     }
@@ -12777,7 +12779,8 @@
                         "gibdd.wanted",
                         "gibdd.wanted.registry",
                         "base.basalt",
-                        "base.granit"
+                        "base.granit",
+                        "wanted.restrict.basalt"
                     ]
                 },
                 "date": {
@@ -12800,7 +12803,8 @@
                                 "gibdd.wanted",
                                 "gibdd.wanted.registry",
                                 "base.basalt",
-                                "base.granit"
+                                "base.granit",
+                                "wanted.restrict.basalt"
                             ]
                         }
                     }

--- a/sources/default/sources_list.json
+++ b/sources/default/sources_list.json
@@ -335,6 +335,11 @@
         "enabled": true
     },
     {
+        "name": "wanted.restrict.basalt",
+        "description": "Данные о нахождении ТС в розыске и ограничениях на регистрационные действия",
+        "enabled": true
+    },
+    {
         "name": "insurance.history.base",
         "description": "История страхования",
         "enabled": true


### PR DESCRIPTION
## Description

Adds a new source `wanted.restrict.basalt` and allows it to fill the following report fields:

- `stealings.is_wanted`
- `stealings.date.update`
- `restrictions.registration_actions.date.update`
- `restrictions.registration_actions.has_restrictions`

Updated `fields_list.json`, `reports/json-schema.json`, `sources_list.json`, and `CHANGELOG.md`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file